### PR TITLE
Support observing model changes to models in transactions fix #17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ python:
   - "3.8"
 
 env:
-  - DJANGO="Django>=1.11,<2.0"
-  - DJANGO="Django>=2.0,<3.0.0"
+  - DJANGO="Django>=2.2,<3.0.0"
   - DJANGO="Django>=3.0.4,<3.0.5"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ sudo: false
 language: python
 
 python:
-  - "3.5"
-  - "3.6"
+  - "3.7"
+  - "3.8"
 
 env:
   - DJANGO="Django>=1.11,<2.0"
-  - DJANGO="Django>=2.0,<2.1"
+  - DJANGO="Django>=2.0,<3.0.0"
+  - DJANGO="Django>=3.0.4,<3.0.5"
 
 install:
   - pip install $DJANGO -e .[tests]

--- a/djangochannelsrestframework/decorators.py
+++ b/djangochannelsrestframework/decorators.py
@@ -12,11 +12,13 @@ def detail_action(**kwargs):
     """
     Used to mark a method on a ResourceBinding that should be routed for detail actions.
     """
+
     def decorator(func):
         func.action = True
         func.detail = True
         func.kwargs = kwargs
         return func
+
     return decorator
 
 
@@ -24,11 +26,13 @@ def list_action(**kwargs):
     """
     Used to mark a method on a ResourceBinding that should be routed for list actions.
     """
+
     def decorator(func):
         func.action = True
         func.detail = False
         func.kwargs = kwargs
         return func
+
     return decorator
 
 
@@ -36,9 +40,10 @@ def action(atomic=None, **kwargs):
     """
     Mark a method as an action.
     """
+
     def decorator(func):
         if atomic is None:
-            _atomic = getattr(settings, 'ATOMIC_REQUESTS', False)
+            _atomic = getattr(settings, "ATOMIC_REQUESTS", False)
         else:
             _atomic = atomic
 
@@ -46,7 +51,7 @@ def action(atomic=None, **kwargs):
         func.kwargs = kwargs
         if asyncio.iscoroutinefunction(func):
             if _atomic:
-                raise ValueError('Only synchronous actions can be atomic')
+                raise ValueError("Only synchronous actions can be atomic")
             return func
 
         if _atomic:
@@ -54,12 +59,9 @@ def action(atomic=None, **kwargs):
             func = transaction.atomic(func)
 
         @wraps(func)
-        async def async_f(self: AsyncAPIConsumer,
-                          *args, **_kwargs):
+        async def async_f(self: AsyncAPIConsumer, *args, **_kwargs):
 
-            result, status = await database_sync_to_async(func)(
-                self, *args, **_kwargs
-            )
+            result, status = await database_sync_to_async(func)(self, *args, **_kwargs)
 
             return result, status
 

--- a/djangochannelsrestframework/generics.py
+++ b/djangochannelsrestframework/generics.py
@@ -24,7 +24,7 @@ class GenericAsyncAPIConsumer(AsyncAPIConsumer):
 
     # If you want to use object lookups other than pk, set 'lookup_field'.
     # For more complex lookup requirements override `get_object()`.
-    lookup_field = 'pk'  # type: str
+    lookup_field = "pk"  # type: str
     lookup_url_kwarg = None  # type: Optional[str]
 
     # TODO filter_backends
@@ -48,8 +48,7 @@ class GenericAsyncAPIConsumer(AsyncAPIConsumer):
         """
         assert self.queryset is not None, (
             "'%s' should either include a `queryset` attribute, "
-            "or override the `get_queryset()` method."
-            % self.__class__.__name__
+            "or override the `get_queryset()` method." % self.__class__.__name__
         )
 
         queryset = self.queryset
@@ -58,7 +57,7 @@ class GenericAsyncAPIConsumer(AsyncAPIConsumer):
             queryset = queryset.all()
         return queryset
 
-    def get_object(self, **kwargs) ->Model:
+    def get_object(self, **kwargs) -> Model:
         """
         Returns the object the view is displaying.
 
@@ -66,19 +65,16 @@ class GenericAsyncAPIConsumer(AsyncAPIConsumer):
         queryset lookups.  Eg if objects are referenced using multiple
         keyword arguments in the url conf.
         """
-        queryset = self.filter_queryset(
-            queryset=self.get_queryset(**kwargs),
-            **kwargs
-        )
+        queryset = self.filter_queryset(queryset=self.get_queryset(**kwargs), **kwargs)
 
         # Perform the lookup filtering.
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
 
         assert lookup_url_kwarg in kwargs, (
-                'Expected view %s to be called with a URL keyword argument '
-                'named "%s". Fix your URL conf, or set the `.lookup_field` '
-                'attribute on the view correctly.' %
-                (self.__class__.__name__, lookup_url_kwarg)
+            "Expected view %s to be called with a URL keyword argument "
+            'named "%s". Fix your URL conf, or set the `.lookup_field` '
+            "attribute on the view correctly."
+            % (self.__class__.__name__, lookup_url_kwarg)
         )
 
         filter_kwargs = {self.lookup_field: kwargs[lookup_url_kwarg]}
@@ -88,21 +84,14 @@ class GenericAsyncAPIConsumer(AsyncAPIConsumer):
 
         return obj
 
-    def get_serializer(
-            self,
-            action_kwargs: Dict=None,
-            *args, **kwargs) -> Serializer:
+    def get_serializer(self, action_kwargs: Dict = None, *args, **kwargs) -> Serializer:
         """
         Return the serializer instance that should be used for validating and
         deserializing input, and for serializing output.
         """
-        serializer_class = self.get_serializer_class(
-            **action_kwargs
-        )
+        serializer_class = self.get_serializer_class(**action_kwargs)
 
-        kwargs['context'] = self.get_serializer_context(
-            **action_kwargs
-        )
+        kwargs["context"] = self.get_serializer_context(**action_kwargs)
 
         return serializer_class(*args, **kwargs)
 
@@ -118,8 +107,7 @@ class GenericAsyncAPIConsumer(AsyncAPIConsumer):
         """
         assert self.serializer_class is not None, (
             "'%s' should either include a `serializer_class` attribute, "
-            "or override the `get_serializer_class()` method."
-            % self.__class__.__name__
+            "or override the `get_serializer_class()` method." % self.__class__.__name__
         )
 
         return self.serializer_class
@@ -128,10 +116,7 @@ class GenericAsyncAPIConsumer(AsyncAPIConsumer):
         """
         Extra context provided to the serializer class.
         """
-        return {
-            'scope': self.scope,
-            'consumer': self
-        }
+        return {"scope": self.scope, "consumer": self}
 
     def filter_queryset(self, queryset: QuerySet, **kwargs):
         """

--- a/djangochannelsrestframework/mixins.py
+++ b/djangochannelsrestframework/mixins.py
@@ -4,7 +4,6 @@ from .decorators import action
 
 
 class CreateModelMixin:
-
     @action()
     def create(self, data, **kwargs):
         serializer = self.get_serializer(data=data, action_kwargs=kwargs)
@@ -17,47 +16,36 @@ class CreateModelMixin:
 
 
 class ListModelMixin:
-
     @action()
     def list(self, **kwargs):
-        queryset = self.filter_queryset(
-            self.get_queryset(**kwargs),
-            **kwargs
-        )
+        queryset = self.filter_queryset(self.get_queryset(**kwargs), **kwargs)
         serializer = self.get_serializer(
-            instance=queryset,
-            many=True,
-            action_kwargs=kwargs
+            instance=queryset, many=True, action_kwargs=kwargs
         )
         return serializer.data, status.HTTP_200_OK
 
 
 class RetrieveModelMixin:
-
     @action()
-    def retrieve(self,**kwargs):
+    def retrieve(self, **kwargs):
         instance = self.get_object(**kwargs)
         serializer = self.get_serializer(instance=instance, action_kwargs=kwargs)
         return serializer.data, status.HTTP_200_OK
 
 
 class UpdateModelMixin:
-
     @action()
     def update(self, data, **kwargs):
         instance = self.get_object(data=data, **kwargs)
 
         serializer = self.get_serializer(
-            instance=instance,
-            data=data,
-            action_kwargs=kwargs,
-            partial=False
+            instance=instance, data=data, action_kwargs=kwargs, partial=False
         )
 
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer, **kwargs)
 
-        if getattr(instance, '_prefetched_objects_cache', None):
+        if getattr(instance, "_prefetched_objects_cache", None):
             # If 'prefetch_related' has been applied to a queryset, we need to
             # forcibly invalidate the prefetch cache on the instance.
             instance._prefetched_objects_cache = {}
@@ -69,22 +57,18 @@ class UpdateModelMixin:
 
 
 class PatchModelMixin:
-
     @action()
     def patch(self, data, **kwargs):
         instance = self.get_object(data=data, **kwargs)
 
         serializer = self.get_serializer(
-            instance=instance,
-            data=data,
-            action_kwargs=kwargs,
-            partial=True
+            instance=instance, data=data, action_kwargs=kwargs, partial=True
         )
 
         serializer.is_valid(raise_exception=True)
         self.perform_patch(serializer, **kwargs)
 
-        if getattr(instance, '_prefetched_objects_cache', None):
+        if getattr(instance, "_prefetched_objects_cache", None):
             # If 'prefetch_related' has been applied to a queryset, we need to
             # forcibly invalidate the prefetch cache on the instance.
             instance._prefetched_objects_cache = {}
@@ -96,9 +80,8 @@ class PatchModelMixin:
 
 
 class DeleteModelMixin:
-
     @action()
-    def delete(self,**kwargs):
+    def delete(self, **kwargs):
         instance = self.get_object(**kwargs)
 
         self.perform_delete(instance, **kwargs)

--- a/djangochannelsrestframework/observer/__init__.py
+++ b/djangochannelsrestframework/observer/__init__.py
@@ -3,7 +3,8 @@ from typing import Type
 
 from django.db.models import Model
 
-from djangochannelsrestframework.observer.observer import ModelObserver, Observer
+from djangochannelsrestframework.observer.observer import Observer
+from djangochannelsrestframework.observer.model_observer import ModelObserver
 
 
 def observer(signal, **kwargs):

--- a/djangochannelsrestframework/observer/base_observer.py
+++ b/djangochannelsrestframework/observer/base_observer.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, Generator
+from uuid import uuid4
+
+from djangochannelsrestframework.consumers import AsyncAPIConsumer
+from djangochannelsrestframework.observer.utils import ObjPartial
+
+
+class BaseObserver:
+    def __init__(self, func):
+        self.func = func
+        self._serializer = None
+        self._group_names = None
+        self._uuid = str(uuid4())
+
+    async def __call__(self, *args, consumer=None, **kwargs):
+        return await self.func(consumer, *args, observer=self, **kwargs)
+
+    def __get__(self, parent, objtype):
+        if parent is None:
+            return self
+
+        return ObjPartial(self, consumer=parent)
+
+    def serialize(self, signal, *args, **kwargs) -> Dict[str, Any]:
+        message = {}
+        if self._serializer:
+            message = self._serializer(self, signal, *args, **kwargs)
+        message["type"] = self.func.__name__.replace("_", ".")
+
+        return message
+
+    def serializer(self, func):
+        self._serializer = func
+        return self
+
+    async def subscribe(self, consumer: AsyncAPIConsumer, *args, **kwargs):
+        for group_name in self.group_names(*args, consumer=consumer, **kwargs):
+            await consumer.add_group(group_name)
+
+    async def unsubscribe(self, consumer: AsyncAPIConsumer, *args, **kwargs):
+        for group_name in self.group_names(*args, consumer=consumer, **kwargs):
+            await consumer.remove_group(group_name)
+
+    def group_names(self, *args, **kwargs) -> Generator[str, None, None]:
+        if self._group_names:
+            for group in self._group_names(*args, **kwargs):
+                yield "{}-{}".format(self._uuid, group)
+            return
+        raise NotImplementedError()
+
+    def groups(self, func):
+        self._group_names = func
+        return self

--- a/djangochannelsrestframework/observer/model_observer.py
+++ b/djangochannelsrestframework/observer/model_observer.py
@@ -1,0 +1,197 @@
+import threading
+import warnings
+from collections import defaultdict
+from enum import Enum
+from functools import partial
+from typing import Type, Dict, Any, Set
+from uuid import uuid4
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.db import transaction
+from django.db.models import Model
+from django.db.models.signals import post_delete, post_save, post_init
+
+from djangochannelsrestframework.observer.base_observer import BaseObserver
+
+"""
+1) not in transaction
+2) in a simple transation with one operations
+3) in a simple transation with mutliple operations
+4) was in a transation but rolled back then outside of a transation saved
+5) was in a transatino but rolled back then inside a new one saved
+6) in a transations savepoint that is never saved
+7) in a transation and then in a save point
+
+
+On each model instance we add a `__observers = {self(id): {tracking info}}`
+"""
+
+
+class Action(Enum):
+    CREATE = "create"
+    UPDATE = "update"
+    DELETE = "delete"
+
+
+class UnsupportedWarning(Warning):
+    """
+
+    """
+
+
+class ModelObserverInstanceState:
+    # this is set when the instance is created
+    current_groups: Set[str] = set()
+
+
+class ModelObserver(BaseObserver):
+    def __init__(self, func, model_cls: Type[Model], **kwargs):
+        super().__init__(func)
+        self._model_cls = None
+        self.model_cls = model_cls  # type: Type[Model]
+        self.id = uuid4()
+
+    @property
+    def model_cls(self) -> Type[Model]:
+        return self._model_cls
+
+    @model_cls.setter
+    def model_cls(self, value: Type[Model]):
+        was_none = self._model_cls is None
+        self._model_cls = value
+
+        if self._model_cls is not None and was_none:
+            self._connect()
+
+    def _connect(self):
+        """
+        Connect the signal listing.
+        """
+
+        # this is used to capture the current state for the model
+        post_init.connect(
+            self.post_init_receiver, sender=self.model_cls, dispatch_uid=id(self)
+        )
+
+        post_save.connect(
+            self.post_save_receiver, sender=self.model_cls, dispatch_uid=id(self)
+        )
+
+        post_delete.connect(
+            self.post_delete_receiver, sender=self.model_cls, dispatch_uid=id(self)
+        )
+
+    def post_init_receiver(self, instance: Model, **kwargs):
+
+        if instance.pk is None:
+            current_groups = set()
+        else:
+            current_groups = set(self.group_names(instance))
+
+        self.get_observer_state(instance).current_groups = current_groups
+
+    def get_observer_state(self, instance: Model) -> ModelObserverInstanceState:
+        # use a thread local dict to be safe...
+        if not hasattr(instance._state, "_thread_local_observers"):
+            instance._state._thread_local_observers = defaultdict(
+                ModelObserverInstanceState
+            )
+
+        return instance._state._thread_local_observers[self.id]
+
+    def post_save_receiver(self, instance: Model, created: bool, **kwargs):
+        """
+        Handle the post save.
+        """
+        if created:
+            self.database_event(instance, Action.CREATE)
+        else:
+            self.database_event(instance, Action.UPDATE)
+
+    def post_delete_receiver(self, instance: Model, **kwargs):
+        self.database_event(instance, Action.DELETE)
+
+    def database_event(self, instance: Model, action: Action):
+
+        connection = transaction.get_connection()
+
+        if connection.in_atomic_block:
+            if len(connection.savepoint_ids) > 0:
+                warnings.warn(
+                    "Model observation with save points is unsupported and will"
+                    " result in unexpected beauvoir.",
+                    UnsupportedWarning,
+                )
+
+        connection.on_commit(partial(self.post_change_receiver, instance, action))
+
+    def post_change_receiver(self, instance: Model, action: Action, **kwargs):
+        """
+        Triggers the old_binding to possibly send to its group.
+        """
+
+        old_group_names = self.get_observer_state(instance).current_groups
+
+        if action == Action.DELETE:
+            new_group_names = set()
+        else:
+            new_group_names = set(self.group_names(instance))
+
+        self.get_observer_state(instance).current_groups = new_group_names
+
+        # if post delete, new_group_names should be []
+
+        # Django DDP had used the ordering of DELETE, UPDATE then CREATE for good reasons.
+        self.send_messages(
+            instance, old_group_names - new_group_names, Action.DELETE, **kwargs
+        )
+        # the object has been updated so that its groups are not the same.
+        self.send_messages(
+            instance, old_group_names & new_group_names, Action.UPDATE, **kwargs
+        )
+
+        #
+        self.send_messages(
+            instance, new_group_names - old_group_names, Action.CREATE, **kwargs
+        )
+
+    def send_messages(
+        self, instance: Model, group_names: Set[str], action: Action, **kwargs
+    ):
+        if not group_names:
+            return
+        message = self.serialize(instance, action, **kwargs)
+        channel_layer = get_channel_layer()
+        for group_name in group_names:
+            async_to_sync(channel_layer.group_send)(group_name, message)
+
+    def group_names(self, *args, **kwargs):
+        if self._group_names:
+            for group in self._group_names(self, *args, **kwargs):
+                yield "{}-{}".format(self._uuid, group)
+            return
+
+        model_label = (
+            "{}.{}".format(
+                self.model_cls._meta.app_label.lower(),
+                self.model_cls._meta.object_name.lower(),
+            )
+            .lower()
+            .replace("_", ".")
+        )
+
+        # one channel for all updates.
+        yield "{}-{}-model-{}".format(
+            self._uuid, self.func.__name__.replace("_", "."), model_label,
+        )
+
+    def serialize(self, instance, action, **kwargs) -> Dict[str, Any]:
+        message = {}
+        if self._serializer:
+            message = self._serializer(self, instance, action, **kwargs)
+        else:
+            message["pk"] = instance.pk
+        message["type"] = self.func.__name__.replace("_", ".")
+        message["action"] = action.value
+        return message

--- a/djangochannelsrestframework/observer/observer.py
+++ b/djangochannelsrestframework/observer/observer.py
@@ -1,87 +1,19 @@
-import threading
-from enum import Enum
-from functools import partial
-from typing import Dict, Any, Type, Set, Generator
-from uuid import uuid4
-
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
-from django.db.models import Model
-from django.db.models.signals import pre_save, post_save, post_delete, \
-    pre_delete
 from django.dispatch import Signal
 
-from djangochannelsrestframework.consumers import AsyncAPIConsumer
-
-
-class ObjPartial(partial):
-    def __getattribute__(self, name):
-        try:
-            item = super().__getattribute__(name)
-        except AttributeError:
-            return partial(getattr(self.func, name), *self.args, **self.keywords)
-        return item
-
-
-class BaseObserver:
-    def __init__(self, func):
-        self.func = func
-        self._serializer = None
-        self._group_names = None
-        self._uuid = str(uuid4())
-
-    async def __call__(self, *args, consumer=None, **kwargs):
-        return await self.func(consumer, *args, observer=self, **kwargs)
-
-    def __get__(self, parent, objtype):
-        if parent is None:
-            return self
-
-        return ObjPartial(self, consumer=parent)
-
-    def serialize(self, signal, *args, **kwargs) -> Dict[str, Any]:
-        message = {}
-        if self._serializer:
-            message = self._serializer(self, signal, *args, **kwargs)
-        message['type'] = self.func.__name__.replace('_', '.')
-
-        return message
-
-    def serializer(self, func):
-        self._serializer = func
-        return self
-
-    async def subscribe(self, consumer: AsyncAPIConsumer, *args, **kwargs):
-        for group_name in self.group_names(*args, consumer=consumer, **kwargs):
-            await consumer.add_group(group_name)
-
-    async def unsubscribe(self, consumer: AsyncAPIConsumer, *args, **kwargs):
-        for group_name in self.group_names(*args, consumer=consumer, **kwargs):
-            await consumer.remove_group(group_name)
-
-    def group_names(self, *args, **kwargs) -> Generator[str, None, None]:
-        if self._group_names:
-            for group in self._group_names(*args, **kwargs):
-                yield '{}-{}'.format(self._uuid, group)
-            return
-        raise NotImplementedError()
-
-    def groups(self, func):
-        self._group_names = func
-        return self
+from djangochannelsrestframework.observer.base_observer import BaseObserver
 
 
 class Observer(BaseObserver):
-    def __init__(self, func, signal: Signal=None, kwargs=None):
+    def __init__(self, func, signal: Signal = None, kwargs=None):
         super().__init__(func)
         if kwargs is None:
             kwargs = {}
         self.signal = signal
         self.signal_kwargs = kwargs
         self._serializer = None
-        self.signal.connect(
-            self.handle, **self.signal_kwargs
-        )
+        self.signal.connect(self.handle, **self.signal_kwargs)
 
     def handle(self, signal, *args, **kwargs):
         message = self.serialize(signal, *args, **kwargs)
@@ -92,174 +24,12 @@ class Observer(BaseObserver):
     def group_names(self, *args, **kwargs):
         if self._group_names:
             for group in self._group_names(*args, **kwargs):
-                yield '{}-{}'.format(self._uuid, group)
+                yield "{}-{}".format(self._uuid, group)
             return
-        yield '{}-{}-signal-{}'.format(
+        yield "{}-{}-signal-{}".format(
             self._uuid,
-            self.func.__name__.replace('_', '.'),
-            '.'.join(
-                arg.lower().replace('_', '.') for arg in
-                self.signal.providing_args
-            )
+            self.func.__name__.replace("_", "."),
+            ".".join(
+                arg.lower().replace("_", ".") for arg in self.signal.providing_args
+            ),
         )
-
-
-class Action(Enum):
-    CREATE = 'create'
-    UPDATE = 'update'
-    DELETE = 'delete'
-
-
-class ModelObserver(BaseObserver):
-
-    def __init__(self, func, model_cls: Type[Model], **kwargs):
-        super().__init__(func)
-        self._model_cls = None
-        self.model_cls = model_cls  # type: Type[Model]
-
-    @property
-    def model_cls(self) -> Type[Model]:
-        return self._model_cls
-
-    @model_cls.setter
-    def model_cls(self, value: Type[Model]):
-        was_none = self._model_cls is None
-        self._model_cls = value
-
-        if self._model_cls is not None and was_none:
-            self._connect()
-
-    def _connect(self):
-        pre_save.connect(
-            self.pre_save_receiver,
-            sender=self.model_cls,
-            dispatch_uid=id(self)
-        )
-        post_save.connect(
-            self.post_save_receiver,
-            sender=self.model_cls,
-            dispatch_uid=id(self)
-        )
-        pre_delete.connect(self.pre_delete_receiver, sender=self.model_cls, dispatch_uid=id(self))
-        post_delete.connect(self.post_delete_receiver, sender=self.model_cls, dispatch_uid=id(self))
-
-    def pre_save_receiver(self, instance: Model, **kwargs):
-        creating = instance._state.adding
-
-        self.pre_change_receiver(
-            instance,
-            Action.CREATE if creating else Action.UPDATE
-        )
-
-    def post_save_receiver(self, instance: Model, created: bool, **kwargs):
-        self.post_change_receiver(
-            instance,
-            Action.CREATE if created else Action.UPDATE,
-            **kwargs
-        )
-
-    def pre_delete_receiver(self, instance: Model, **kwargs):
-
-        self.pre_change_receiver(
-            instance,
-            Action.DELETE
-        )
-
-    def post_delete_receiver(self, instance: Model, **kwargs):
-        self.post_change_receiver(instance, Action.DELETE, **kwargs)
-
-    def pre_change_receiver(self, instance: Model, action: Action):
-        """
-        Entry point for triggering the old_binding from save signals.
-        """
-        if action == Action.CREATE:
-            group_names = set()
-        else:
-            group_names = set(self.group_names(instance))
-
-        # use a thread local dict to be safe...
-        if not hasattr(instance, '__instance_groups'):
-            instance.__instance_groups = threading.local()
-            instance.__instance_groups.observers = {}
-        if not hasattr(instance.__instance_groups, 'observers'):
-            instance.__instance_groups.observers = {}
-
-        instance.__instance_groups.observers[self] = group_names
-
-    def post_change_receiver(self, instance: Model, action: Action, **kwargs):
-        """
-        Triggers the old_binding to possibly send to its group.
-        """
-        try:
-            old_group_names = instance.__instance_groups.observers[self]
-        except (ValueError, KeyError):
-            old_group_names = set()
-
-        if action == Action.DELETE:
-            new_group_names = set()
-        else:
-            new_group_names = set(self.group_names(instance))
-
-        # if post delete, new_group_names should be []
-
-        # Django DDP had used the ordering of DELETE, UPDATE then CREATE for good reasons.
-        self.send_messages(
-            instance,
-            old_group_names - new_group_names,
-            Action.DELETE,
-            **kwargs
-        )
-        # the object has been updated so that its groups are not the same.
-        self.send_messages(
-            instance,
-            old_group_names & new_group_names,
-            Action.UPDATE,
-            **kwargs
-        )
-
-        #
-        self.send_messages(
-            instance,
-            new_group_names - old_group_names,
-            Action.CREATE,
-            **kwargs
-        )
-
-    def send_messages(self,
-                      instance: Model,
-                      group_names: Set[str],
-                      action: Action, **kwargs):
-        if not group_names:
-            return
-        message = self.serialize(instance, action, **kwargs)
-        channel_layer = get_channel_layer()
-        for group_name in group_names:
-            async_to_sync(channel_layer.group_send)(group_name, message)
-
-    def group_names(self, *args, **kwargs):
-        if self._group_names:
-            for group in self._group_names(self, *args, **kwargs):
-                yield '{}-{}'.format(self._uuid, group)
-            return
-
-        model_label = '{}.{}'.format(
-            self.model_cls._meta.app_label.lower(),
-            self.model_cls._meta.object_name.lower()
-        ).lower().replace('_', '.')
-
-        # one channel for all updates.
-        yield '{}-{}-model-{}'.format(
-            self._uuid,
-            self.func.__name__.replace('_', '.'),
-            model_label,
-        )
-
-    def serialize(self, instance, action, **kwargs) -> Dict[str, Any]:
-        message = {}
-        if self._serializer:
-            message = self._serializer(self, instance, action, **kwargs)
-        else:
-            message['pk'] = instance.pk
-        message['type'] = self.func.__name__.replace('_', '.')
-        message['action'] = action.value
-        return message

--- a/djangochannelsrestframework/observer/utils.py
+++ b/djangochannelsrestframework/observer/utils.py
@@ -1,0 +1,18 @@
+from functools import partial
+
+
+class ObjPartial(partial):
+    """
+    This is used to access methods of the `observer` from the attached
+    `consumer` without passing the consumer as and argument.
+
+    The `__get__` method of the observer is used to inject the (parent) into
+    as an argument into the methods you call.
+    """
+
+    def __getattribute__(self, name: str):
+        try:
+            item = super().__getattribute__(name)
+        except AttributeError:
+            return partial(getattr(self.func, name), *self.args, **self.keywords)
+        return item

--- a/djangochannelsrestframework/permissions.py
+++ b/djangochannelsrestframework/permissions.py
@@ -4,26 +4,24 @@ from channels.consumer import AsyncConsumer
 
 
 class BasePermission:
-
-    async def has_permission(self, scope: Dict[str, Any],
-                             consumer: AsyncConsumer,
-                             action: str, **kwargs) -> bool:
+    async def has_permission(
+        self, scope: Dict[str, Any], consumer: AsyncConsumer, action: str, **kwargs
+    ) -> bool:
         pass
 
 
 class AllowAny(BasePermission):
-    async def has_permission(self, scope: Dict[str, Any],
-                             consumer: AsyncConsumer,
-                             action: str, **kwargs) -> bool:
+    async def has_permission(
+        self, scope: Dict[str, Any], consumer: AsyncConsumer, action: str, **kwargs
+    ) -> bool:
         return True
 
 
 class IsAuthenticated(BasePermission):
-    async def has_permission(self,
-                             scope: Dict[str, Any],
-                             consumer: AsyncConsumer,
-                             action: str, **kwargs) -> bool:
-        user = scope.get('user')
+    async def has_permission(
+        self, scope: Dict[str, Any], consumer: AsyncConsumer, action: str, **kwargs
+    ) -> bool:
+        user = scope.get("user")
         if not user:
             return False
         return user.pk and user.is_authenticated

--- a/djangochannelsrestframework/settings.py
+++ b/djangochannelsrestframework/settings.py
@@ -3,13 +3,11 @@ from django.conf import settings
 from rest_framework.settings import APISettings
 
 DEFAULTS = {
-    'DEFAULT_PAGE_SIZE': 25,
-    'DEFAULT_PERMISSION_CLASSES': (
-        'djangochannelsrestframework.permissions.AllowAny',
-    )
+    "DEFAULT_PAGE_SIZE": 25,
+    "DEFAULT_PERMISSION_CLASSES": ("djangochannelsrestframework.permissions.AllowAny",),
 }
-IMPORT_STRINGS = (
-    'DEFAULT_PERMISSION_CLASSES',
-)
+IMPORT_STRINGS = ("DEFAULT_PERMISSION_CLASSES",)
 
-api_settings = APISettings(getattr(settings, 'DJANGO_CHANNELS_REST_API', None), DEFAULTS, IMPORT_STRINGS)
+api_settings = APISettings(
+    getattr(settings, "DJANGO_CHANNELS_REST_API", None), DEFAULTS, IMPORT_STRINGS
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=1.8
+django>=2.2
 djangorestframework>=3
 channels>=2.1.1
 pytest-django

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,27 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='djangochannelsrestframework',
-    version="0.0.3",
-    url='https://github.com/hishnash/djangochannelsrestframework',
-    author='Matthaus Woolard',
-    author_email='matthaus.woolard@gmail.com',
+    name="djangochannelsrestframework",
+    version="0.0.4",
+    url="https://github.com/hishnash/djangochannelsrestframework",
+    author="Matthaus Woolard",
+    author_email="matthaus.woolard@gmail.com",
     description="RESTful API for WebSockets using django channels.",
-    long_description=open('README.rst').read(),
-    license='MIT',
-    packages=find_packages(exclude=['tests']),
+    long_description=open("README.rst").read(),
+    license="MIT",
+    packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=[
-        'Django>=1.11',
-        'channels>=2.1.1',
-        'djangorestframework>=3.0'
-    ],
+    install_requires=["Django>=1.11", "channels>=2.1.1", "djangorestframework>=3.0"],
     extras_require={
-        'tests': [
-            'pytest~=3.7.1',
+        "tests": [
+            "pytest~=3.7.1",
             "pytest-django~=3.4.1",
             "pytest-asyncio~=0.9",
-            'coverage~=4.4',
+            "coverage~=4.4",
         ],
     },
     classifiers=[
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-    ]
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+    ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,19 +4,13 @@ from django.conf import settings
 def pytest_configure():
     settings.configure(
         INSTALLED_APPS=(
-            'django.contrib.auth',
-            'django.contrib.contenttypes',
-            'django.contrib.sessions',
-            'channels',
-            'tests'
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "django.contrib.sessions",
+            "channels",
+            "tests",
         ),
-        SECRET_KEY='dog',
-
-        DATABASES={
-            'default': {
-                'ENGINE': 'django.db.backends.sqlite3',
-            }
-        },
-
-        MIDDLEWARE_CLASSES=[]
+        SECRET_KEY="dog",
+        DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3",}},
+        MIDDLEWARE_CLASSES=[],
     )

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -9,15 +9,22 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='TestModel',
+            name="TestModel",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
             ],
         ),
     ]

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -12,16 +12,15 @@ async def test_decorator():
     results = {}
 
     class AConsumer(AsyncAPIConsumer):
-
         @action()
         async def test_async_action(self, pk=None, **kwargs):
-            results['test_action'] = pk
-            return {'pk': pk}, 200
+            results["test_action"] = pk
+            return {"pk": pk}, 200
 
         @action()
         def test_sync_action(self, pk=None, **kwargs):
-            results['test_sync_action'] = pk
-            return {'pk': pk, 'sync': True}, 200
+            results["test_sync_action"] = pk
+            return {"pk": pk, "sync": True}, 200
 
     # Test a normal connection
     communicator = WebsocketCommunicator(AConsumer, "/testws/")
@@ -31,39 +30,31 @@ async def test_decorator():
     assert connected
 
     await communicator.send_json_to(
-        {
-            "action": "test_async_action",
-            "pk": 2,
-            "request_id": 1
-        }
+        {"action": "test_async_action", "pk": 2, "request_id": 1}
     )
 
     response = await communicator.receive_json_from()
 
     assert response == {
-        'errors': [],
-        'data': {'pk': 2},
-        'action': 'test_async_action',
-        'response_status': 200,
-        'request_id': 1
+        "errors": [],
+        "data": {"pk": 2},
+        "action": "test_async_action",
+        "response_status": 200,
+        "request_id": 1,
     }
 
     await communicator.send_json_to(
-        {
-            "action": "test_sync_action",
-            "pk": 3,
-            "request_id": 10
-        }
+        {"action": "test_sync_action", "pk": 3, "request_id": 10}
     )
 
     response = await communicator.receive_json_from()
 
     assert response == {
-        'errors': [],
-        'data': {'pk': 3, 'sync': True},
-        'action': 'test_sync_action',
-        'response_status': 200,
-        'request_id': 10
+        "errors": [],
+        "data": {"pk": 3, "sync": True},
+        "action": "test_sync_action",
+        "response_status": 200,
+        "request_id": 10,
     }
 
     await communicator.disconnect()

--- a/tests/test_django_view_consumer.py
+++ b/tests/test_django_view_consumer.py
@@ -12,35 +12,28 @@ async def test_view_as_consumer():
     results = {}
 
     class TestView(APIView):
-
         def get(self, request, format=None):
-            results['TestView-get'] = True
-            return Response(['test1', 'test2'])
+            results["TestView-get"] = True
+            return Response(["test1", "test2"])
 
     # Test a normal connection
-    communicator = WebsocketCommunicator(view_as_consumer(
-        TestView.as_view()),
-        "/testws/"
+    communicator = WebsocketCommunicator(
+        view_as_consumer(TestView.as_view()), "/testws/"
     )
 
     connected, _ = await communicator.connect()
     assert connected
 
-    await communicator.send_json_to(
-        {
-            "action": "retrieve",
-            "request_id": 1
-        }
-    )
+    await communicator.send_json_to({"action": "retrieve", "request_id": 1})
 
     response = await communicator.receive_json_from()
 
-    assert 'TestView-get' in results
+    assert "TestView-get" in results
 
     assert response == {
-        'errors': [],
-        'data': ['test1', 'test2'],
-        'action': 'retrieve',
-        'response_status': 200,
-        'request_id': 1
+        "errors": [],
+        "data": ["test1", "test2"],
+        "action": "retrieve",
+        "response_status": 200,
+        "request_id": 1,
     }

--- a/tests/test_generic_consumer.py
+++ b/tests/test_generic_consumer.py
@@ -11,18 +11,21 @@ from djangochannelsrestframework.mixins import (
     RetrieveModelMixin,
     UpdateModelMixin,
     PatchModelMixin,
-    DeleteModelMixin
+    DeleteModelMixin,
 )
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_generic_consumer():
-
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
-            fields = ('id', 'username', 'email',)
+            fields = (
+                "id",
+                "username",
+                "email",
+            )
 
     class AConsumer(GenericAsyncAPIConsumer):
         queryset = get_user_model().objects.all()
@@ -32,10 +35,7 @@ async def test_generic_consumer():
         def test_sync_action(self, pk=None, **kwargs):
             user = self.get_object(pk=pk)
 
-            s = self.get_serializer(
-                action_kwargs={'pk': pk},
-                instance=user
-            )
+            s = self.get_serializer(action_kwargs={"pk": pk}, instance=user)
             return s.data, 200
 
     # Test a normal connection
@@ -44,26 +44,20 @@ async def test_generic_consumer():
     assert connected
 
     await communicator.send_json_to(
-        {
-            "action": "test_sync_action",
-            "pk": 2,
-            "request_id": 1
-        }
+        {"action": "test_sync_action", "pk": 2, "request_id": 1}
     )
 
     response = await communicator.receive_json_from()
 
     assert response == {
-            "action": "test_sync_action",
-            "errors": ["Not found"],
-            "response_status": 404,
-            "request_id": 1,
-            "data": None,
-        }
+        "action": "test_sync_action",
+        "errors": ["Not found"],
+        "response_status": 404,
+        "request_id": 1,
+        "data": None,
+    }
 
-    user = get_user_model().objects.create(
-        username='test1', email='test@example.com'
-    )
+    user = get_user_model().objects.create(username="test1", email="test@example.com")
 
     pk = user.id
 
@@ -77,11 +71,7 @@ async def test_generic_consumer():
     assert connected
 
     await communicator.send_json_to(
-        {
-            "action": "test_sync_action",
-            "pk": pk,
-            "request_id": 2
-        }
+        {"action": "test_sync_action", "pk": pk, "request_id": 2}
     )
 
     response = await communicator.receive_json_from()
@@ -91,7 +81,7 @@ async def test_generic_consumer():
         "errors": [],
         "response_status": 200,
         "request_id": 2,
-        "data": {'email': 'test@example.com', 'id': 1, 'username': 'test1'}
+        "data": {"email": "test@example.com", "id": 1, "username": "test1"},
     }
 
     await communicator.disconnect()
@@ -100,11 +90,14 @@ async def test_generic_consumer():
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_create_mixin_consumer():
-
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
-            fields = ('id', 'username', 'email',)
+            fields = (
+                "id",
+                "username",
+                "email",
+            )
 
     class AConsumer(CreateModelMixin, GenericAsyncAPIConsumer):
         queryset = get_user_model().objects.all()
@@ -120,11 +113,8 @@ async def test_create_mixin_consumer():
     await communicator.send_json_to(
         {
             "action": "create",
-            "data": {
-                "username": "test101",
-                "email": "42@example.com"
-            },
-            "request_id": 1
+            "data": {"username": "test101", "email": "42@example.com"},
+            "request_id": 1,
         }
     )
 
@@ -139,18 +129,21 @@ async def test_create_mixin_consumer():
         "errors": [],
         "response_status": 201,
         "request_id": 1,
-        "data": {'email': '42@example.com', 'id': pk, 'username': 'test101'}
+        "data": {"email": "42@example.com", "id": pk, "username": "test101"},
     }
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_list_mixin_consumer():
-
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
-            fields = ('id', 'username', 'email',)
+            fields = (
+                "id",
+                "username",
+                "email",
+            )
 
     class AConsumer(ListModelMixin, GenericAsyncAPIConsumer):
         queryset = get_user_model().objects.all()
@@ -163,12 +156,7 @@ async def test_list_mixin_consumer():
     connected, _ = await communicator.connect()
     assert connected
 
-    await communicator.send_json_to(
-        {
-            "action": "list",
-            "request_id": 1
-        }
-    )
+    await communicator.send_json_to({"action": "list", "request_id": 1})
 
     response = await communicator.receive_json_from()
 
@@ -177,22 +165,13 @@ async def test_list_mixin_consumer():
         "errors": [],
         "response_status": 200,
         "request_id": 1,
-        "data": []
+        "data": [],
     }
 
-    u1 = get_user_model().objects.create(
-        username='test1', email='42@example.com'
-    )
-    u2 = get_user_model().objects.create(
-        username='test2', email='45@example.com'
-    )
+    u1 = get_user_model().objects.create(username="test1", email="42@example.com")
+    u2 = get_user_model().objects.create(username="test2", email="45@example.com")
 
-    await communicator.send_json_to(
-        {
-            "action": "list",
-            "request_id": 1
-        }
-    )
+    await communicator.send_json_to({"action": "list", "request_id": 1})
 
     response = await communicator.receive_json_from()
 
@@ -202,20 +181,23 @@ async def test_list_mixin_consumer():
         "response_status": 200,
         "request_id": 1,
         "data": [
-            {'email': '42@example.com', 'id': u1.id, 'username': 'test1'},
-            {'email': '45@example.com', 'id': u2.id, 'username': 'test2'}
-        ]
+            {"email": "42@example.com", "id": u1.id, "username": "test1"},
+            {"email": "45@example.com", "id": u2.id, "username": "test2"},
+        ],
     }
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_retrieve_mixin_consumer():
-
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
-            fields = ('id', 'username', 'email',)
+            fields = (
+                "id",
+                "username",
+                "email",
+            )
 
     class AConsumer(RetrieveModelMixin, GenericAsyncAPIConsumer):
         queryset = get_user_model().objects.all()
@@ -228,13 +210,7 @@ async def test_retrieve_mixin_consumer():
     connected, _ = await communicator.connect()
     assert connected
 
-    await communicator.send_json_to(
-        {
-            "action": "retrieve",
-            "pk": 100,
-            "request_id": 1
-        }
-    )
+    await communicator.send_json_to({"action": "retrieve", "pk": 100, "request_id": 1})
 
     response = await communicator.receive_json_from()
 
@@ -243,23 +219,15 @@ async def test_retrieve_mixin_consumer():
         "errors": ["Not found"],
         "response_status": 404,
         "request_id": 1,
-        "data": None
+        "data": None,
     }
 
-    u1 = get_user_model().objects.create(
-        username='test1', email='42@example.com'
-    )
-    u2 = get_user_model().objects.create(
-        username='test2', email='45@example.com'
-    )
+    u1 = get_user_model().objects.create(username="test1", email="42@example.com")
+    u2 = get_user_model().objects.create(username="test2", email="45@example.com")
 
     # lookup a pk that is not there
     await communicator.send_json_to(
-        {
-            "action": "retrieve",
-            "pk": u1.id - 1,
-            "request_id": 1
-        }
+        {"action": "retrieve", "pk": u1.id - 1, "request_id": 1}
     )
 
     response = await communicator.receive_json_from()
@@ -269,16 +237,12 @@ async def test_retrieve_mixin_consumer():
         "errors": ["Not found"],
         "response_status": 404,
         "request_id": 1,
-        "data": None
+        "data": None,
     }
 
     # lookup up u1
     await communicator.send_json_to(
-        {
-            "action": "retrieve",
-            "pk": u1.id,
-            "request_id": 1
-        }
+        {"action": "retrieve", "pk": u1.id, "request_id": 1}
     )
 
     response = await communicator.receive_json_from()
@@ -288,20 +252,21 @@ async def test_retrieve_mixin_consumer():
         "errors": [],
         "response_status": 200,
         "request_id": 1,
-        "data": {
-            'email': '42@example.com', 'id': u1.id, 'username': 'test1'
-        }
+        "data": {"email": "42@example.com", "id": u1.id, "username": "test1"},
     }
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_update_mixin_consumer():
-
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
-            fields = ('id', 'username', 'email',)
+            fields = (
+                "id",
+                "username",
+                "email",
+            )
 
     class AConsumer(UpdateModelMixin, GenericAsyncAPIConsumer):
         queryset = get_user_model().objects.all()
@@ -318,11 +283,8 @@ async def test_update_mixin_consumer():
         {
             "action": "update",
             "pk": 100,
-            "data": {
-                "username": "test101",
-                "email": "42@example.com"
-            },
-            "request_id": 1
+            "data": {"username": "test101", "email": "42@example.com"},
+            "request_id": 1,
         }
     )
 
@@ -333,24 +295,18 @@ async def test_update_mixin_consumer():
         "errors": ["Not found"],
         "response_status": 404,
         "request_id": 1,
-        "data": None
+        "data": None,
     }
 
-    u1 = get_user_model().objects.create(
-        username='test1', email='42@example.com'
-    )
-    get_user_model().objects.create(
-        username='test2', email='45@example.com'
-    )
+    u1 = get_user_model().objects.create(username="test1", email="42@example.com")
+    get_user_model().objects.create(username="test2", email="45@example.com")
 
     await communicator.send_json_to(
         {
             "action": "update",
             "pk": u1.id,
-            "data": {
-                "username": "test101",
-            },
-            "request_id": 2
+            "data": {"username": "test101",},
+            "request_id": 2,
         }
     )
 
@@ -361,22 +317,25 @@ async def test_update_mixin_consumer():
         "errors": [],
         "response_status": 200,
         "request_id": 2,
-        "data": {'email': '42@example.com', 'id': u1.id, 'username': 'test101'}
+        "data": {"email": "42@example.com", "id": u1.id, "username": "test101"},
     }
 
     u1 = get_user_model().objects.get(id=u1.id)
-    assert u1.username == 'test101'
-    assert u1.email == '42@example.com'
+    assert u1.username == "test101"
+    assert u1.email == "42@example.com"
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_patch_mixin_consumer():
-
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
-            fields = ('id', 'username', 'email',)
+            fields = (
+                "id",
+                "username",
+                "email",
+            )
 
     class AConsumer(PatchModelMixin, GenericAsyncAPIConsumer):
         queryset = get_user_model().objects.all()
@@ -393,11 +352,8 @@ async def test_patch_mixin_consumer():
         {
             "action": "patch",
             "pk": 100,
-            "data": {
-                "username": "test101",
-                "email": "42@example.com"
-            },
-            "request_id": 1
+            "data": {"username": "test101", "email": "42@example.com"},
+            "request_id": 1,
         }
     )
 
@@ -408,24 +364,18 @@ async def test_patch_mixin_consumer():
         "errors": ["Not found"],
         "response_status": 404,
         "request_id": 1,
-        "data": None
+        "data": None,
     }
 
-    u1 = get_user_model().objects.create(
-        username='test1', email='42@example.com'
-    )
-    get_user_model().objects.create(
-        username='test2', email='45@example.com'
-    )
+    u1 = get_user_model().objects.create(username="test1", email="42@example.com")
+    get_user_model().objects.create(username="test2", email="45@example.com")
 
     await communicator.send_json_to(
         {
             "action": "patch",
             "pk": u1.id,
-            "data": {
-                "email": "00@example.com",
-            },
-            "request_id": 2
+            "data": {"email": "00@example.com",},
+            "request_id": 2,
         }
     )
 
@@ -436,22 +386,25 @@ async def test_patch_mixin_consumer():
         "errors": [],
         "response_status": 200,
         "request_id": 2,
-        "data": {'email': '00@example.com', 'id': u1.id, 'username': 'test1'}
+        "data": {"email": "00@example.com", "id": u1.id, "username": "test1"},
     }
 
     u1 = get_user_model().objects.get(id=u1.id)
-    assert u1.username == 'test1'
-    assert u1.email == '00@example.com'
+    assert u1.username == "test1"
+    assert u1.email == "00@example.com"
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_delete_mixin_consumer():
-
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
-            fields = ('id', 'username', 'email',)
+            fields = (
+                "id",
+                "username",
+                "email",
+            )
 
     class AConsumer(DeleteModelMixin, GenericAsyncAPIConsumer):
         queryset = get_user_model().objects.all()
@@ -464,12 +417,23 @@ async def test_delete_mixin_consumer():
     connected, _ = await communicator.connect()
     assert connected
 
+    await communicator.send_json_to({"action": "delete", "pk": 100, "request_id": 1})
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "action": "delete",
+        "errors": ["Not found"],
+        "response_status": 404,
+        "request_id": 1,
+        "data": None,
+    }
+
+    u1 = get_user_model().objects.create(username="test1", email="42@example.com")
+    get_user_model().objects.create(username="test2", email="45@example.com")
+
     await communicator.send_json_to(
-        {
-            "action": "delete",
-            "pk": 100,
-            "request_id": 1
-        }
+        {"action": "delete", "pk": u1.id - 1, "request_id": 1}
     )
 
     response = await communicator.receive_json_from()
@@ -479,41 +443,10 @@ async def test_delete_mixin_consumer():
         "errors": ["Not found"],
         "response_status": 404,
         "request_id": 1,
-        "data": None
+        "data": None,
     }
 
-    u1 = get_user_model().objects.create(
-        username='test1', email='42@example.com'
-    )
-    get_user_model().objects.create(
-        username='test2', email='45@example.com'
-    )
-
-    await communicator.send_json_to(
-        {
-            "action": "delete",
-            "pk": u1.id - 1,
-            "request_id": 1
-        }
-    )
-
-    response = await communicator.receive_json_from()
-
-    assert response == {
-        "action": "delete",
-        "errors": ["Not found"],
-        "response_status": 404,
-        "request_id": 1,
-        "data": None
-    }
-
-    await communicator.send_json_to(
-        {
-            "action": "delete",
-            "pk": u1.id,
-            "request_id": 1
-        }
-    )
+    await communicator.send_json_to({"action": "delete", "pk": u1.id, "request_id": 1})
 
     response = await communicator.receive_json_from()
 
@@ -522,7 +455,7 @@ async def test_delete_mixin_consumer():
         "errors": [],
         "response_status": 204,
         "request_id": 1,
-        "data": None
+        "data": None,
     }
 
     assert not get_user_model().objects.filter(id=u1.id).exists()

--- a/tests/test_model_observer.py
+++ b/tests/test_model_observer.py
@@ -17,18 +17,20 @@ from tests.models import TestModel
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
-        fields = ('id', 'username', 'email',)
+        fields = (
+            "id",
+            "username",
+            "email",
+        )
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_observer_model_instance_mixin(settings):
-    settings.CHANNEL_LAYERS={
+    settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {
-                "expiry": 100500,
-            },
+            "TEST_CONFIG": {"expiry": 100500,},
         },
     }
 
@@ -47,7 +49,7 @@ async def test_observer_model_instance_mixin(settings):
             user = await database_sync_to_async(self.get_object)(pk=pk)
             user.username = username
             await database_sync_to_async(user.save)()
-            return {'pk': pk}, 200
+            return {"pk": pk}, 200
 
     assert not await database_sync_to_async(get_user_model().objects.all().exists)()
 
@@ -56,13 +58,7 @@ async def test_observer_model_instance_mixin(settings):
     connected, _ = await communicator.connect()
     assert connected
 
-    await communicator.send_json_to(
-        {
-            "action": "retrieve",
-            "pk": 100,
-            "request_id": 1
-        }
-    )
+    await communicator.send_json_to({"action": "retrieve", "pk": 100, "request_id": 1})
 
     response = await communicator.receive_json_from()
 
@@ -71,23 +67,19 @@ async def test_observer_model_instance_mixin(settings):
         "errors": ["Not found"],
         "response_status": 404,
         "request_id": 1,
-        "data": None
+        "data": None,
     }
 
     u1 = await database_sync_to_async(get_user_model().objects.create)(
-        username='test1', email='42@example.com'
+        username="test1", email="42@example.com"
     )
     u2 = await database_sync_to_async(get_user_model().objects.create)(
-        username='test2', email='45@example.com'
+        username="test2", email="45@example.com"
     )
 
     # lookup a pk that is not there
     await communicator.send_json_to(
-        {
-            "action": "retrieve",
-            "pk": u1.id - 1,
-            "request_id": 1
-        }
+        {"action": "retrieve", "pk": u1.id - 1, "request_id": 1}
     )
 
     response = await communicator.receive_json_from()
@@ -97,16 +89,12 @@ async def test_observer_model_instance_mixin(settings):
         "errors": ["Not found"],
         "response_status": 404,
         "request_id": 1,
-        "data": None
+        "data": None,
     }
 
     # lookup up u1
     await communicator.send_json_to(
-        {
-            "action": "retrieve",
-            "pk": u1.id,
-            "request_id": 1
-        }
+        {"action": "retrieve", "pk": u1.id, "request_id": 1}
     )
 
     response = await communicator.receive_json_from()
@@ -116,18 +104,12 @@ async def test_observer_model_instance_mixin(settings):
         "errors": [],
         "response_status": 200,
         "request_id": 1,
-        "data": {
-            'email': '42@example.com', 'id': u1.id, 'username': 'test1'
-        }
+        "data": {"email": "42@example.com", "id": u1.id, "username": "test1"},
     }
 
     # lookup up u1
     await communicator.send_json_to(
-        {
-            "action": "subscribe_instance",
-            "pk": u1.id,
-            "request_id": 4
-        }
+        {"action": "subscribe_instance", "pk": u1.id, "request_id": 4}
     )
 
     response = await communicator.receive_json_from()
@@ -137,11 +119,11 @@ async def test_observer_model_instance_mixin(settings):
         "errors": [],
         "response_status": 201,
         "request_id": 4,
-        "data": None
+        "data": None,
     }
 
     u3 = await database_sync_to_async(get_user_model().objects.create)(
-        username='test3', email='46@example.com'
+        username="test3", email="46@example.com"
     )
 
     # lookup up u1
@@ -150,7 +132,7 @@ async def test_observer_model_instance_mixin(settings):
             "action": "update_username",
             "pk": u1.id,
             "username": "thenewname",
-            "request_id": 5
+            "request_id": 5,
         }
     )
 
@@ -161,17 +143,17 @@ async def test_observer_model_instance_mixin(settings):
         "errors": [],
         "response_status": 200,
         "request_id": 5,
-        "data": {'pk': u1.id}
+        "data": {"pk": u1.id},
     }
 
     response = await communicator.receive_json_from()
-
+    print(response)
     assert response == {
         "action": "update",
         "errors": [],
         "response_status": 200,
         "request_id": 4,
-        "data": {'email': '42@example.com', 'id': 13, 'username': 'thenewname'},
+        "data": {"email": "42@example.com", "id": u1.id, "username": "thenewname"},
     }
 
     await database_sync_to_async(u1.delete)()
@@ -183,7 +165,7 @@ async def test_observer_model_instance_mixin(settings):
         "errors": [],
         "response_status": 204,
         "request_id": 4,
-        "data": {'pk': 13},
+        "data": {"pk": 13},
     }
 
     await communicator.disconnect()
@@ -192,12 +174,10 @@ async def test_observer_model_instance_mixin(settings):
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_two_observer_model_instance_mixins(settings):
-    settings.CHANNEL_LAYERS={
+    settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {
-                "expiry": 100500,
-            },
+            "TEST_CONFIG": {"expiry": 100500,},
         },
     }
 
@@ -216,7 +196,7 @@ async def test_two_observer_model_instance_mixins(settings):
             user = await database_sync_to_async(self.get_object)(pk=pk)
             user.username = username
             await database_sync_to_async(user.save)()
-            return {'pk': pk}, 200
+            return {"pk": pk}, 200
 
     class TestOtherConsumer(ObserverModelInstanceMixin, GenericAsyncAPIConsumer):
 
@@ -231,10 +211,9 @@ async def test_two_observer_model_instance_mixins(settings):
             tm = await database_sync_to_async(self.get_object)(pk=pk)
             tm.name = name
             await database_sync_to_async(tm.save)()
-            return {'pk': pk}, 200
+            return {"pk": pk}, 200
 
-    assert not await database_sync_to_async(
-        get_user_model().objects.all().exists)()
+    assert not await database_sync_to_async(get_user_model().objects.all().exists)()
 
     # Test a normal connection
     communicator1 = WebsocketCommunicator(TestOtherConsumer, "/testws/")
@@ -247,18 +226,12 @@ async def test_two_observer_model_instance_mixins(settings):
     assert connected
 
     u1 = await database_sync_to_async(get_user_model().objects.create)(
-        username='test1', email='42@example.com'
+        username="test1", email="42@example.com"
     )
-    t1 = await database_sync_to_async(TestModel.objects.create)(
-        name='test2'
-    )
+    t1 = await database_sync_to_async(TestModel.objects.create)(name="test2")
 
     await communicator1.send_json_to(
-        {
-            "action": "subscribe_instance",
-            "pk": t1.id,
-            "request_id": 4
-        }
+        {"action": "subscribe_instance", "pk": t1.id, "request_id": 4}
     )
 
     response = await communicator1.receive_json_from()
@@ -268,15 +241,11 @@ async def test_two_observer_model_instance_mixins(settings):
         "errors": [],
         "response_status": 201,
         "request_id": 4,
-        "data": None
+        "data": None,
     }
 
     await communicator2.send_json_to(
-        {
-            "action": "subscribe_instance",
-            "pk": u1.id,
-            "request_id": 4
-        }
+        {"action": "subscribe_instance", "pk": u1.id, "request_id": 4}
     )
 
     response = await communicator2.receive_json_from()
@@ -286,12 +255,12 @@ async def test_two_observer_model_instance_mixins(settings):
         "errors": [],
         "response_status": 201,
         "request_id": 4,
-        "data": None
+        "data": None,
     }
 
     # update the user
 
-    u1.username = 'no not a value'
+    u1.username = "no not a value"
 
     await database_sync_to_async(u1.save)()
 
@@ -305,12 +274,10 @@ async def test_two_observer_model_instance_mixins(settings):
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_unsubscribe_observer_model_instance_mixin(settings):
-    settings.CHANNEL_LAYERS={
+    settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {
-                "expiry": 100500,
-            },
+            "TEST_CONFIG": {"expiry": 100500,},
         },
     }
 
@@ -329,7 +296,7 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
             user = await database_sync_to_async(self.get_object)(pk=pk)
             user.username = username
             await database_sync_to_async(user.save)()
-            return {'pk': pk}, 200
+            return {"pk": pk}, 200
 
     assert not await database_sync_to_async(get_user_model().objects.all().exists)()
 
@@ -339,16 +306,12 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
     assert connected
 
     u1 = await database_sync_to_async(get_user_model().objects.create)(
-        username='test1', email='42@example.com'
+        username="test1", email="42@example.com"
     )
 
     # lookup up u1
     await communicator.send_json_to(
-        {
-            "action": "subscribe_instance",
-            "pk": u1.id,
-            "request_id": 4
-        }
+        {"action": "subscribe_instance", "pk": u1.id, "request_id": 4}
     )
 
     response = await communicator.receive_json_from()
@@ -358,7 +321,7 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
         "errors": [],
         "response_status": 201,
         "request_id": 4,
-        "data": None
+        "data": None,
     }
 
     await communicator.send_json_to(
@@ -366,7 +329,7 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
             "action": "update_username",
             "pk": u1.id,
             "username": "thenewname",
-            "request_id": 5
+            "request_id": 5,
         }
     )
 
@@ -377,7 +340,7 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
         "errors": [],
         "response_status": 200,
         "request_id": 5,
-        "data": {'pk': u1.id}
+        "data": {"pk": u1.id},
     }
 
     response = await communicator.receive_json_from()
@@ -387,18 +350,14 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
         "errors": [],
         "response_status": 200,
         "request_id": 4,
-        "data": {'email': '42@example.com', 'id': u1.pk, 'username': 'thenewname'},
+        "data": {"email": "42@example.com", "id": u1.pk, "username": "thenewname"},
     }
 
     # unsubscribe
     # lookup up u1
 
     await communicator.send_json_to(
-        {
-            "action": "unsubscribe_instance",
-            "pk": u1.id,
-            "request_id": 4
-        }
+        {"action": "unsubscribe_instance", "pk": u1.id, "request_id": 4}
     )
 
     response = await communicator.receive_json_from()
@@ -408,7 +367,7 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
         "errors": [],
         "response_status": 204,
         "request_id": 4,
-        "data": None
+        "data": None,
     }
 
     await communicator.send_json_to(
@@ -416,7 +375,7 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
             "action": "update_username",
             "pk": u1.id,
             "username": "thenewname",
-            "request_id": 5
+            "request_id": 5,
         }
     )
 
@@ -427,7 +386,7 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
         "errors": [],
         "response_status": 200,
         "request_id": 5,
-        "data": {'pk': u1.id}
+        "data": {"pk": u1.id},
     }
 
     await communicator.disconnect()

--- a/tests/test_model_observer.py
+++ b/tests/test_model_observer.py
@@ -147,7 +147,7 @@ async def test_observer_model_instance_mixin(settings):
     }
 
     response = await communicator.receive_json_from()
-    print(response)
+
     assert response == {
         "action": "update",
         "errors": [],

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,12 +1,14 @@
 import asyncio
 
 import pytest
+from asgiref.sync import async_to_sync
 from channels import DEFAULT_CHANNEL_LAYER
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from channels.layers import channel_layers
 from channels.testing import WebsocketCommunicator
 from django.contrib.auth import user_logged_in, get_user_model
+from django.db import transaction
 from django.utils.text import slugify
 
 from djangochannelsrestframework.consumers import AsyncAPIConsumer
@@ -16,30 +18,23 @@ from djangochannelsrestframework.observer import observer, model_observer
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_observer_wrapper(settings):
-    settings.CHANNEL_LAYERS={
+    settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {
-                "expiry": 100500,
-            },
+            "TEST_CONFIG": {"expiry": 100500,},
         },
     }
 
     layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
 
     class TestConsumer(AsyncAPIConsumer):
-
         async def accept(self):
             await TestConsumer.handle_user_logged_in.subscribe(self)
             await super().accept()
 
         @observer(user_logged_in)
         async def handle_user_logged_in(self, *args, observer=None, **kwargs):
-            await self.send_json({
-                    'message': kwargs,
-                    'observer': observer is not None
-                }
-            )
+            await self.send_json({"message": kwargs, "observer": observer is not None})
 
     communicator = WebsocketCommunicator(TestConsumer, "/testws/")
 
@@ -48,19 +43,16 @@ async def test_observer_wrapper(settings):
     assert connected
 
     user = await database_sync_to_async(get_user_model().objects.create)(
-        username='test',
-        email='test@example.com'
+        username="test", email="test@example.com"
     )
 
     await database_sync_to_async(user_logged_in.send)(
-        sender=user.__class__,
-        request=None,
-        user=user
+        sender=user.__class__, request=None, user=user
     )
 
     response = await communicator.receive_json_from()
 
-    assert {'message': {}, 'observer': True} == response
+    assert {"message": {}, "observer": True} == response
 
     await communicator.disconnect()
 
@@ -68,19 +60,16 @@ async def test_observer_wrapper(settings):
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_model_observer_wrapper(settings):
-    settings.CHANNEL_LAYERS={
+    settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {
-                "expiry": 100500,
-            },
+            "TEST_CONFIG": {"expiry": 100500,},
         },
     }
 
     layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
 
     class TestConsumer(AsyncAPIConsumer):
-
         async def accept(self):
             await TestConsumer.user_change.subscribe(self)
             await super().accept()
@@ -96,37 +85,29 @@ async def test_model_observer_wrapper(settings):
     assert connected
 
     user = await database_sync_to_async(get_user_model().objects.create)(
-        username='test',
-        email='test@example.com'
+        username="test", email="test@example.com"
     )
 
     response = await communicator.receive_json_from()
 
-    assert {
-               'action': 'create',
-               'pk': user.pk,
-               'type': 'user.change'
-           } == response
+    assert {"action": "create", "pk": user.pk, "type": "user.change"} == response
 
     await communicator.disconnect()
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_model_observer_delete_wrapper(settings):
-    settings.CHANNEL_LAYERS={
+async def test_model_observer_wrapper_in_transaction(settings):
+    settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {
-                "expiry": 100500,
-            },
+            "TEST_CONFIG": {"expiry": 100500,},
         },
     }
 
     layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
 
     class TestConsumer(AsyncAPIConsumer):
-
         async def accept(self):
             await TestConsumer.user_change.subscribe(self)
             await super().accept()
@@ -140,33 +121,70 @@ async def test_model_observer_delete_wrapper(settings):
     connected, _ = await communicator.connect()
 
     assert connected
-    print("before create ---------------")
-    user = await database_sync_to_async(get_user_model())(
-        username='test',
-        email='test@example.com'
-    )
-    print('not saved yet ------' )
-    await database_sync_to_async(user.save)()
-    print("after create ---------------")
+
+    @database_sync_to_async
+    def create_user_and_wait():
+
+        with transaction.atomic():
+            user = get_user_model().objects.create(
+                username="test", email="test@example.com"
+            )
+            assert async_to_sync(communicator.receive_nothing(timeout=0.1))
+            user.username = "mike"
+            user.save()
+            assert async_to_sync(communicator.receive_nothing(timeout=0.1))
+            return user
+
+    user = await create_user_and_wait()
 
     response = await communicator.receive_json_from()
 
-    assert {
-               'action': 'create',
-               'pk': user.pk,
-               'type': 'user.change'
-           } == response
+    assert {"action": "create", "pk": user.pk, "type": "user.change"} == response
+
+    await communicator.disconnect()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_model_observer_delete_wrapper(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500,},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
+    class TestConsumer(AsyncAPIConsumer):
+        async def accept(self):
+            await TestConsumer.user_change.subscribe(self)
+            await super().accept()
+
+        @model_observer(get_user_model())
+        async def user_change(self, message, observer=None, **kwargs):
+            await self.send_json(message)
+
+    communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected
+    user = await database_sync_to_async(get_user_model())(
+        username="test", email="test@example.com"
+    )
+    await database_sync_to_async(user.save)()
+
+    response = await communicator.receive_json_from()
+
+    assert {"action": "create", "pk": user.pk, "type": "user.change"} == response
     pk = user.pk
 
     await database_sync_to_async(user.delete)()
 
     response = await communicator.receive_json_from()
 
-    assert {
-        'action': 'delete',
-        'pk': pk,
-        'type': 'user.change'
-    } == response
+    assert {"action": "delete", "pk": pk, "type": "user.change"} == response
 
     await communicator.disconnect()
 
@@ -174,19 +192,16 @@ async def test_model_observer_delete_wrapper(settings):
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_model_observer_many_connections_wrapper(settings):
-    settings.CHANNEL_LAYERS={
+    settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {
-                "expiry": 100500,
-            },
+            "TEST_CONFIG": {"expiry": 100500,},
         },
     }
 
     layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
 
     class TestConsumer(AsyncAPIConsumer):
-
         async def accept(self):
             await TestConsumer.user_change.subscribe(self)
             await super().accept()
@@ -208,27 +223,18 @@ async def test_model_observer_many_connections_wrapper(settings):
     assert connected
 
     user = await database_sync_to_async(get_user_model().objects.create)(
-        username='test',
-        email='test@example.com'
+        username="test", email="test@example.com"
     )
 
     response = await communicator1.receive_json_from()
 
-    assert {
-               'action': 'create',
-               'pk': user.pk,
-               'type': 'user.change'
-           } == response
+    assert {"action": "create", "pk": user.pk, "type": "user.change"} == response
 
     await communicator1.disconnect()
 
     response = await communicator2.receive_json_from()
 
-    assert {
-               'action': 'create',
-               'pk': user.pk,
-               'type': 'user.change'
-           } == response
+    assert {"action": "create", "pk": user.pk, "type": "user.change"} == response
 
     await communicator2.disconnect()
 
@@ -236,20 +242,17 @@ async def test_model_observer_many_connections_wrapper(settings):
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_model_observer_many_consumers_wrapper(settings):
-    settings.CHANNEL_LAYERS={
+    settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {
-                "expiry": 100500,
-            },
+            "TEST_CONFIG": {"expiry": 100500,},
         },
     }
 
     layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
 
     class TestConsumer(AsyncAPIConsumer):
-
-        async def accept(self):
+        async def accept(self, **kwargs):
             await self.user_change.subscribe()
             await super().accept()
 
@@ -258,8 +261,7 @@ async def test_model_observer_many_consumers_wrapper(settings):
             await self.send_json(message)
 
     class TestConsumer2(AsyncAPIConsumer):
-
-        async def accept(self):
+        async def accept(self, **kwargs):
             await self.user_other.subscribe()
             await super().accept()
 
@@ -280,27 +282,18 @@ async def test_model_observer_many_consumers_wrapper(settings):
     assert connected
 
     user = await database_sync_to_async(get_user_model().objects.create)(
-        username='test',
-        email='test@example.com'
+        username="test", email="test@example.com"
     )
 
     response = await communicator1.receive_json_from()
 
-    assert {
-               'action': 'create',
-               'pk': user.pk,
-               'type': 'user.change'
-           } == response
+    assert {"action": "create", "pk": user.pk, "type": "user.change"} == response
 
     await communicator1.disconnect()
 
     response = await communicator2.receive_json_from()
 
-    assert {
-               'action': 'create',
-               'pk': user.pk,
-               'type': 'user.other'
-           } == response
+    assert {"action": "create", "pk": user.pk, "type": "user.other"} == response
 
     await communicator2.disconnect()
 
@@ -308,21 +301,18 @@ async def test_model_observer_many_consumers_wrapper(settings):
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_model_observer_custom_groups_wrapper(settings):
-    settings.CHANNEL_LAYERS={
+    settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {
-                "expiry": 100500,
-            },
+            "TEST_CONFIG": {"expiry": 100500,},
         },
     }
 
     layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
 
     class TestConsumer(AsyncAPIConsumer):
-
-        async def accept(self):
-            await self.user_change.subscribe(username='test')
+        async def accept(self, **kwargs):
+            await self.user_change.subscribe(username="test")
             await super().accept()
 
         @model_observer(get_user_model())
@@ -332,9 +322,9 @@ async def test_model_observer_custom_groups_wrapper(settings):
         @user_change.groups
         def user_change(self, instance=None, username=None, **kwargs):
             if username:
-                yield '-instance-username-{}'.format(slugify(username))
+                yield "-instance-username-{}".format(slugify(username))
             else:
-                yield '-instance-username-{}'.format(instance.username)
+                yield "-instance-username-{}".format(instance.username)
 
     communicator = WebsocketCommunicator(TestConsumer, "/testws/")
 
@@ -343,23 +333,17 @@ async def test_model_observer_custom_groups_wrapper(settings):
     assert connected
 
     user = await database_sync_to_async(get_user_model().objects.create)(
-        username='test',
-        email='test@example.com'
+        username="test", email="test@example.com"
     )
 
     response = await communicator.receive_json_from()
 
-    assert {
-               'action': 'create',
-               'pk': user.pk,
-               'type': 'user.change'
-           } == response
+    assert {"action": "create", "pk": user.pk, "type": "user.change"} == response
 
     await communicator.disconnect()
 
     user = await database_sync_to_async(get_user_model().objects.create)(
-        username='test2',
-        email='test@example.com'
+        username="test2", email="test@example.com"
     )
 
     # no event since this is only subscribed to 'test'


### PR DESCRIPTION
This does 2 things

- [x] Observe model changes that are made in a transaction when the transaction completes
- [x] Handle model updates (for custom group naming system) better

there is one side effect of this change is that the group name is computed  durring the `init` of a model so it is important that you do not need to do a query to build your group name.


TOOD:

- [x] Expand with multiple tests on how this performs. 