### PR TITLE
Fix #42

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,11 +178,11 @@ One can subscribe to all instances of a model by utilizing the ``model_observer`
     from djangochannelsrestframework.observer import model_observer
 
     @model_observer(models.Test)
-    async def model_activity(self, message, observer=None, **kwargs):
+    async def model_activity(self, message, observer=None, action=None, **kwargs):
         # send activity to your frontend
         await self.send_json(message)
 
-This method will send messages to the client on all CRUD operations made through the Django ORM.
+This method will send messages to the client on all CRUD operations made through the Django ORM. The `action` arg here it will take values such as `create`, `delete` and `update` you should consider passing this to your frontend client.
 
 Note: These notifications do not include bulk updates, such as ``models.Test.objects.filter(name="abc").update(name="newname")``
 
@@ -210,7 +210,7 @@ You can do this in a few placed, a common example is in the ``websocket_connect`
         await self.activities_change.subscribe()
 
 
-This method utilizes the previously mentioned ``model_activity`` method to subscribe to all instances of the current Consumer's model. 
+This method utilizes the previously mentioned ``model_activity`` method to subscribe to all instances of the current Consumer's model.
 
 One can also subscribe by creating a custom action
 
@@ -225,7 +225,7 @@ Another way is override ``AsyncAPIConsumer.accept(self, **kwargs)``
         
 
         @model_observer(models.Test)
-        async def model_change(self, message, **kwargs):
+        async def model_change(self, message, action=None, **kwargs):
             await self.send_json(message)
 
 Subscribing to a filtered list of models
@@ -241,11 +241,11 @@ To do this we need to split the model updates into `groups` and then in the cons
   class MyConsumer(AsyncAPIConsumer):
 
     @model_observer(models.Classroom)
-    async def classroom_change_handler(self, message, observer=None, **kwargs):
+    async def classroom_change_handler(self, message, observer=None, action=None, **kwargs):
         # due to not being able to make DB QUERIES when selecting a group
         # maybe do an extra check here to be sure the user has permission
         # send activity to your frontend
-        await self.send_json(message)
+        await self.send_json(dict(body=message, action=action))
 
     @classroom_change_handler.groups_for_signal
     def classroom_change_handler(self, instance: models.Classroom, **kwargs):

--- a/djangochannelsrestframework/observer/base_observer.py
+++ b/djangochannelsrestframework/observer/base_observer.py
@@ -1,6 +1,6 @@
 import hashlib
-from typing import Any, Dict, Generator, Callable, Optional
-from uuid import uuid4
+from copy import deepcopy
+from typing import Any, Dict, Generator, Callable, Iterable
 
 from djangochannelsrestframework.consumers import AsyncAPIConsumer
 from djangochannelsrestframework.observer.utils import ObjPartial
@@ -13,10 +13,26 @@ class BaseObserver:
         self._group_names_for_signal = None
         self._group_names_for_consumer = None
 
-        self._stable_observer_id = f"{partition}-{self.__class__.__name__}-{self.func.__module__}.{self.func.__name__}"
+        self._stable_observer_id = (
+            f"{partition}-"
+            f"{self.__class__.__name__}-"
+            f"{self.func.__module__}."
+            f"{self.func.__name__}"
+        )
 
-    async def __call__(self, *args, consumer=None, **kwargs):
-        return await self.func(consumer, *args, observer=self, **kwargs)
+    async def __call__(self, message, consumer=None, **kwargs):
+        message = deepcopy(message)
+        message_body = message.pop("body", {})
+        message_type = message.pop("type")
+
+        return await self.func(
+            consumer,
+            message_body,
+            observer=self,
+            message_type=message_type,
+            **message,
+            **kwargs,
+        )
 
     def __get__(self, parent, objtype):
         if parent is None:
@@ -25,10 +41,11 @@ class BaseObserver:
         return ObjPartial(self, consumer=parent)
 
     def serialize(self, signal, *args, **kwargs) -> Dict[str, Any]:
-        message = {}
+        message_body = {}
         if self._serializer:
-            message = self._serializer(self, signal, *args, **kwargs)
-        message["type"] = self.func.__name__.replace("_", ".")
+            message_body = self._serializer(self, signal, *args, **kwargs)
+
+        message = dict(type=self.func.__name__.replace("_", "."), body=message_body)
 
         return message
 
@@ -36,17 +53,24 @@ class BaseObserver:
         self._serializer = func
         return self
 
-    async def subscribe(self, consumer: AsyncAPIConsumer, *args, **kwargs):
-        for group_name in self.group_names_for_consumer(
-            *args, consumer=consumer, **kwargs
-        ):
-            await consumer.add_group(group_name)
+    async def subscribe(
+        self, consumer: AsyncAPIConsumer, *args, **kwargs
+    ) -> Iterable[str]:
+        groups = list(self.group_names_for_consumer(*args, consumer=consumer, **kwargs))
 
-    async def unsubscribe(self, consumer: AsyncAPIConsumer, *args, **kwargs):
-        for group_name in self.group_names_for_consumer(
-            *args, consumer=consumer, **kwargs
-        ):
+        for group_name in groups:
+            await consumer.add_group(group_name)
+        return groups
+
+    async def unsubscribe(
+        self, consumer: AsyncAPIConsumer, *args, **kwargs
+    ) -> Iterable[str]:
+        groups = list(self.group_names_for_consumer(*args, consumer=consumer, **kwargs))
+
+        for group_name in groups:
             await consumer.remove_group(group_name)
+
+        return groups
 
     def group_names_for_consumer(
         self, consumer: AsyncAPIConsumer, *args, **kwargs

--- a/djangochannelsrestframework/observer/model_observer.py
+++ b/djangochannelsrestframework/observer/model_observer.py
@@ -1,6 +1,7 @@
 import threading
 import warnings
 from collections import defaultdict
+from copy import deepcopy
 from enum import Enum
 from functools import partial
 from typing import Type, Dict, Any, Set, overload, Optional
@@ -164,8 +165,14 @@ class ModelObserver(BaseObserver):
             return
         message = self.serialize(instance, action, **kwargs)
         channel_layer = get_channel_layer()
+
         for group_name in group_names:
-            async_to_sync(channel_layer.group_send)(group_name, message)
+            message_to_send = deepcopy(message)
+
+            # Include the group name in the message being sent
+            message_to_send["group"] = group_name
+
+            async_to_sync(channel_layer.group_send)(group_name, message_to_send)
 
     def group_names(self, *args, **kwargs):
         # one channel for all updates.
@@ -176,13 +183,18 @@ class ModelObserver(BaseObserver):
         )
 
     def serialize(self, instance, action, **kwargs) -> Dict[str, Any]:
-        message = {}
+        message_body = {}
         if self._serializer:
-            message = self._serializer(self, instance, action, **kwargs)
+            message_body = self._serializer(self, instance, action, **kwargs)
         else:
-            message["pk"] = instance.pk
-        message["type"] = self.func.__name__.replace("_", ".")
-        message["action"] = action.value
+            message_body["pk"] = instance.pk
+
+        message = dict(
+            type=self.func.__name__.replace("_", "."),
+            body=message_body,
+            action=action.value,
+        )
+
         return message
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        subscribed_requests,
     ],
 )

--- a/tests/test_model_observer.py
+++ b/tests/test_model_observer.py
@@ -392,3 +392,140 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
     }
 
     await communicator.disconnect()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_observer_model_instance_mixin_with_many_subs(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
+    class TestConsumerMultipleSubs(ObserverModelInstanceMixin, GenericAsyncAPIConsumer):
+
+        queryset = get_user_model().objects.all()
+        serializer_class = UserSerializer
+
+        async def accept(self, subprotocol=None):
+            await super().accept()
+
+        @action()
+        async def update_username(self, pk=None, username=None, **kwargs):
+            user = await database_sync_to_async(self.get_object)(pk=pk)
+            user.username = username
+            await database_sync_to_async(user.save)()
+            return {"pk": pk}, 200
+
+    assert not await database_sync_to_async(get_user_model().objects.all().exists)()
+
+    # Test a normal connection
+    communicator = WebsocketCommunicator(TestConsumerMultipleSubs(), "/testws/")
+    connected, _ = await communicator.connect()
+    assert connected
+
+    u1 = await database_sync_to_async(get_user_model().objects.create)(
+        username="test1", email="42@example.com"
+    )
+
+    u2 = await database_sync_to_async(get_user_model().objects.create)(
+        username="test2", email="45@example.com"
+    )
+
+    # Subscribe to instance user 1
+    await communicator.send_json_to(
+        {"action": "subscribe_instance", "pk": u1.id, "request_id": 4}
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "action": "subscribe_instance",
+        "errors": [],
+        "response_status": 201,
+        "request_id": 4,
+        "data": None,
+    }
+
+    # Subscribe to instance user 2
+    await communicator.send_json_to(
+        {"action": "subscribe_instance", "pk": u2.id, "request_id": 5}
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "action": "subscribe_instance",
+        "errors": [],
+        "response_status": 201,
+        "request_id": 5,
+        "data": None,
+    }
+
+    # lookup up u1
+    await communicator.send_json_to(
+        {
+            "action": "update_username",
+            "pk": u1.id,
+            "username": "new name",
+            "request_id": 10,
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "action": "update_username",
+        "errors": [],
+        "response_status": 200,
+        "request_id": 10,
+        "data": {"pk": u1.id},
+    }
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "action": "update",
+        "errors": [],
+        "response_status": 200,
+        "request_id": 4,
+        "data": {"email": "42@example.com", "id": u1.id, "username": "new name"},
+    }
+
+    assert await communicator.receive_nothing()
+
+    # Update U2
+    await communicator.send_json_to(
+        {
+            "action": "update_username",
+            "pk": u2.id,
+            "username": "the new name 2",
+            "request_id": 11,
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "action": "update_username",
+        "errors": [],
+        "response_status": 200,
+        "request_id": 11,
+        "data": {"pk": u2.id},
+    }
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "action": "update",
+        "errors": [],
+        "response_status": 200,
+        "request_id": 5,
+        "data": {"email": "45@example.com", "id": u2.id, "username": "the new name 2"},
+    }
+
+    await communicator.disconnect()

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -32,8 +32,8 @@ async def test_observer_wrapper(settings):
             await super().accept()
 
         @observer(user_logged_in)
-        async def handle_user_logged_in(self, *args, observer=None, **kwargs):
-            await self.send_json({"message": kwargs, "observer": observer is not None})
+        async def handle_user_logged_in(self, message, observer=None, **kwargs):
+            await self.send_json({"message": message, "observer": observer is not None})
 
     communicator = WebsocketCommunicator(TestConsumer(), "/testws/")
 
@@ -74,8 +74,10 @@ async def test_model_observer_wrapper(settings):
             await super().accept()
 
         @model_observer(get_user_model())
-        async def user_change_observer_wrapper(self, message, observer=None, **kwargs):
-            await self.send_json(message)
+        async def user_change_observer_wrapper(
+            self, message, action, message_type, observer=None, **kwargs
+        ):
+            await self.send_json(dict(body=message, action=action, type=message_type))
 
     communicator = WebsocketCommunicator(TestConsumer(), "/testws/")
 
@@ -91,7 +93,7 @@ async def test_model_observer_wrapper(settings):
 
     assert {
         "action": "create",
-        "pk": user.pk,
+        "body": {"pk": user.pk},
         "type": "user.change.observer.wrapper",
     } == response
 
@@ -117,9 +119,9 @@ async def test_model_observer_wrapper_in_transaction(settings):
 
         @model_observer(get_user_model())
         async def user_change_wrapper_in_transaction(
-            self, message, observer=None, **kwargs
+            self, message, action, message_type, observer=None, **kwargs
         ):
-            await self.send_json(message)
+            await self.send_json(dict(body=message, action=action, type=message_type))
 
     communicator = WebsocketCommunicator(TestConsumer(), "/testws/")
 
@@ -146,7 +148,7 @@ async def test_model_observer_wrapper_in_transaction(settings):
 
     assert {
         "action": "create",
-        "pk": user.pk,
+        "body": {"pk": user.pk},
         "type": "user.change.wrapper.in.transaction",
     } == response
 
@@ -171,8 +173,10 @@ async def test_model_observer_delete_wrapper(settings):
             await super().accept()
 
         @model_observer(get_user_model())
-        async def user_change_observer_delete(self, message, observer=None, **kwargs):
-            await self.send_json(message)
+        async def user_change_observer_delete(
+            self, message, action, message_type, observer=None, **kwargs
+        ):
+            await self.send_json(dict(body=message, action=action, type=message_type))
 
     communicator = WebsocketCommunicator(TestConsumerObserverDelete(), "/testws/")
 
@@ -191,7 +195,7 @@ async def test_model_observer_delete_wrapper(settings):
 
     assert {
         "action": "create",
-        "pk": user.pk,
+        "body": {"pk": user.pk},
         "type": "user.change.observer.delete",
     } == response
     pk = user.pk
@@ -204,7 +208,7 @@ async def test_model_observer_delete_wrapper(settings):
 
     assert {
         "action": "delete",
-        "pk": pk,
+        "body": {"pk": pk},
         "type": "user.change.observer.delete",
     } == response
 
@@ -229,8 +233,10 @@ async def test_model_observer_many_connections_wrapper(settings):
             await super().accept()
 
         @model_observer(get_user_model())
-        async def user_change_many_connections_wrapper(self, message, **kwargs):
-            await self.send_json(message)
+        async def user_change_many_connections_wrapper(
+            self, message, action, message_type, observer=None, **kwargs
+        ):
+            await self.send_json(dict(body=message, action=action, type=message_type))
 
     communicator1 = WebsocketCommunicator(TestConsumer(), "/testws/")
 
@@ -252,7 +258,7 @@ async def test_model_observer_many_connections_wrapper(settings):
 
     assert {
         "action": "create",
-        "pk": user.pk,
+        "body": {"pk": user.pk},
         "type": "user.change.many.connections.wrapper",
     } == response
 
@@ -262,7 +268,7 @@ async def test_model_observer_many_connections_wrapper(settings):
 
     assert {
         "action": "create",
-        "pk": user.pk,
+        "body": {"pk": user.pk},
         "type": "user.change.many.connections.wrapper",
     } == response
 
@@ -287,8 +293,10 @@ async def test_model_observer_many_consumers_wrapper(settings):
             await super().accept()
 
         @model_observer(get_user_model())
-        async def user_change_many_consumers_wrapper_1(self, message, **kwargs):
-            await self.send_json(message)
+        async def user_change_many_consumers_wrapper_1(
+            self, message, action, message_type, observer=None, **kwargs
+        ):
+            await self.send_json(dict(body=message, action=action, type=message_type))
 
     class TestConsumer2(AsyncAPIConsumer):
         async def accept(self, **kwargs):
@@ -296,8 +304,10 @@ async def test_model_observer_many_consumers_wrapper(settings):
             await super().accept()
 
         @model_observer(get_user_model())
-        async def user_change_many_consumers_wrapper_2(self, message, **kwargs):
-            await self.send_json(message)
+        async def user_change_many_consumers_wrapper_2(
+            self, message, action, message_type, observer=None, **kwargs
+        ):
+            await self.send_json(dict(body=message, action=action, type=message_type))
 
     communicator1 = WebsocketCommunicator(TestConsumer(), "/testws/")
 
@@ -319,7 +329,7 @@ async def test_model_observer_many_consumers_wrapper(settings):
 
     assert {
         "action": "create",
-        "pk": user.pk,
+        "body": {"pk": user.pk},
         "type": "user.change.many.consumers.wrapper.1",
     } == response
 
@@ -329,7 +339,7 @@ async def test_model_observer_many_consumers_wrapper(settings):
 
     assert {
         "action": "create",
-        "pk": user.pk,
+        "body": {"pk": user.pk},
         "type": "user.change.many.consumers.wrapper.2",
     } == response
 
@@ -354,8 +364,10 @@ async def test_model_observer_custom_groups_wrapper(settings):
             await super().accept()
 
         @model_observer(get_user_model())
-        async def user_change_custom_groups_wrapper(self, message, **kwargs):
-            await self.send_json(message)
+        async def user_change_custom_groups_wrapper(
+            self, message, action, message_type, observer=None, **kwargs
+        ):
+            await self.send_json(dict(body=message, action=action, type=message_type))
 
         @user_change_custom_groups_wrapper.groups
         def user_change_custom_groups_wrapper(
@@ -380,7 +392,7 @@ async def test_model_observer_custom_groups_wrapper(settings):
 
     assert {
         "action": "create",
-        "pk": user.pk,
+        "body": {"pk": user.pk},
         "type": "user.change.custom.groups.wrapper",
     } == response
 
@@ -413,8 +425,10 @@ async def test_model_observer_custom_groups_wrapper_with_split_function_api(sett
             await super().accept()
 
         @model_observer(get_user_model())
-        async def user_change_custom_groups(self, message, **kwargs):
-            await self.send_json(message)
+        async def user_change_custom_groups(
+            self, message, action, message_type, observer=None, **kwargs
+        ):
+            await self.send_json(dict(body=message, action=action, type=message_type))
 
         @user_change_custom_groups.groups_for_signal
         def user_change_custom_groups(self, instance=None, **kwargs):
@@ -438,7 +452,7 @@ async def test_model_observer_custom_groups_wrapper_with_split_function_api(sett
 
     assert {
         "action": "create",
-        "pk": user.pk,
+        "body": {"pk": user.pk},
         "type": "user.change.custom.groups",
     } == response
 


### PR DESCRIPTION
This fix includes some other changes.

TODO:

- [x] map group ids to request_ids and use this to send to the correct request ids
- [ ] add more tests with respect to subscribing and un-subscribing when multiple subscriptions to the same consumer are active.