### PR TITLE
Fix #64

### DIFF
--- a/djangochannelsrestframework/decorators.py
+++ b/djangochannelsrestframework/decorators.py
@@ -43,23 +43,23 @@ def action(atomic=None, **kwargs):
 
     def decorator(func):
         _atomic = False
-        
+
         if atomic is not None:
             _atomic = atomic
-        
+
         func.action = True
         func.kwargs = kwargs
-        
+
         if asyncio.iscoroutinefunction(func):
             if _atomic:
                 raise ValueError("Only synchronous actions can be atomic")
             return func
-        
+
         # Read out default atomic state from DB connection
         if atomic is None:
             databases = getattr(settings, "DATABASES", {})
             database = databases.get("default", {})
-            _atomic =  database.get("ATOMIC_REQUESTS", False)
+            _atomic = database.get("ATOMIC_REQUESTS", False)
 
         if _atomic:
             # wrap function in atomic wrapper

--- a/djangochannelsrestframework/decorators.py
+++ b/djangochannelsrestframework/decorators.py
@@ -42,17 +42,24 @@ def action(atomic=None, **kwargs):
     """
 
     def decorator(func):
-        if atomic is None:
-            _atomic = getattr(settings, "ATOMIC_REQUESTS", False)
-        else:
+        _atomic = False
+        
+        if atomic is not None:
             _atomic = atomic
-
+        
         func.action = True
         func.kwargs = kwargs
+        
         if asyncio.iscoroutinefunction(func):
             if _atomic:
                 raise ValueError("Only synchronous actions can be atomic")
             return func
+        
+        # Read out default atomic state from DB connection
+        if atomic is None:
+            databases = getattr(settings, "DATABASES", {})
+            database = databases.get("default", {})
+            _atomic =  database.get("ATOMIC_REQUESTS", False)
 
         if _atomic:
             # wrap function in atomic wrapper

--- a/djangochannelsrestframework/observer/generics.py
+++ b/djangochannelsrestframework/observer/generics.py
@@ -116,7 +116,9 @@ class ObserverModelInstanceMixin(ObserverConsumerMixin, RetrieveModelMixin):
         self, message: Dict, group=None, action=None, **kwargs
     ):
         await self.handle_observed_action(
-            action=action, group=group, **message,
+            action=action,
+            group=group,
+            **message,
         )
 
     @handle_instance_change.groups

--- a/djangochannelsrestframework/observer/model_observer.py
+++ b/djangochannelsrestframework/observer/model_observer.py
@@ -37,9 +37,7 @@ class Action(Enum):
 
 
 class UnsupportedWarning(Warning):
-    """
-
-    """
+    """"""
 
 
 class ModelObserverInstanceState:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-django>=3.0
-djangorestframework>=3
-channels>=3.0
+django>=3.2
+djangorestframework>=3.12.4
+channels>=3.0.3
 pytest
 pytest-asyncio
 pytest-django
 sphinx
+black==20.8b1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,10 @@ def pytest_configure():
             "tests",
         ),
         SECRET_KEY="dog",
-        DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3",}},
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+            }
+        },
         MIDDLEWARE_CLASSES=[],
     )

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,64 @@
+import pytest
+from django.db import transaction, connection, connections
+
+from djangochannelsrestframework.decorators import action
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_async_action_works_with_atomic_request_on(settings):
+    settings.DATABASES["default"]["ATOMIC_REQUESTS"] = True
+
+    @action()
+    async def simple_action():
+        return True
+
+    result = await simple_action()
+    assert result
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_async_action_fails_when_atomic():
+
+    with pytest.raises(ValueError):
+
+        @action(atomic=True)
+        async def simple_action():
+            return True
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_sync_action_when_atomic():
+    @action(atomic=True)
+    def simple_action(self):
+        return connections["default"].in_atomic_block, None
+
+    result, _ = await simple_action(None)
+    assert result
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_sync_action_when_not_atomic():
+    @action(atomic=False)
+    def simple_action(self):
+        return connections["default"].in_atomic_block, None
+
+    result, _ = await simple_action(None)
+    assert not result
+
+
+@pytest.mark.parametrize("atomic", [True, False])
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_sync_action_users_settings(settings, atomic):
+    settings.DATABASES["default"]["ATOMIC_REQUESTS"] = atomic
+
+    @action()
+    def simple_action(self):
+        return connections["default"].in_atomic_block, None
+
+    result, _ = await simple_action(None)
+    assert result == atomic

--- a/tests/test_generic_consumer.py
+++ b/tests/test_generic_consumer.py
@@ -320,7 +320,9 @@ async def test_update_mixin_consumer():
         {
             "action": "update",
             "pk": u1.id,
-            "data": {"username": "test101",},
+            "data": {
+                "username": "test101",
+            },
             "request_id": 2,
         }
     )
@@ -393,7 +395,9 @@ async def test_patch_mixin_consumer():
         {
             "action": "patch",
             "pk": u1.id,
-            "data": {"email": "00@example.com",},
+            "data": {
+                "email": "00@example.com",
+            },
             "request_id": 2,
         }
     )

--- a/tests/test_model_observer.py
+++ b/tests/test_model_observer.py
@@ -30,7 +30,9 @@ async def test_observer_model_instance_mixin(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 
@@ -177,7 +179,9 @@ async def test_two_observer_model_instance_mixins(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 
@@ -277,7 +281,9 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -20,7 +20,9 @@ async def test_observer_wrapper(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 
@@ -62,7 +64,9 @@ async def test_model_observer_wrapper(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 
@@ -106,7 +110,9 @@ async def test_model_observer_wrapper_in_transaction(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 
@@ -161,7 +167,9 @@ async def test_model_observer_delete_wrapper(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 
@@ -221,7 +229,9 @@ async def test_model_observer_many_connections_wrapper(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 
@@ -281,7 +291,9 @@ async def test_model_observer_many_consumers_wrapper(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 
@@ -352,7 +364,9 @@ async def test_model_observer_custom_groups_wrapper(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 
@@ -413,7 +427,9 @@ async def test_model_observer_custom_groups_wrapper_with_split_function_api(sett
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 


### PR DESCRIPTION
Change to read DB `ATOMIC_REQUESTS` value after async function call.


- [x] Added fix
- [x] Write unit tests to expose this
- [x] Create ticket for supporting Django's [multi DB routing](https://docs.djangoproject.com/en/3.2/topics/db/multi-db/#topics-db-multi-db-routing) #66
