### PR TITLE
Feature/add serializer class in model observer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -294,6 +294,23 @@ Another way is override ``AsyncAPIConsumer.accept(self, **kwargs)``
         def model_serialize(self, instance, action, **kwargs):
             return TestSerializer(instance).data
 
+.. note::
+
+    New Feature!
+    Now you can rewrite this as:
+    .. code-block:: python
+
+        class ModelConsumerObserver(AsyncAPIConsumer):
+            async def accept(self, **kwargs):
+                await super().accept(** kwargs)
+                await self.model_change.subscribe()
+            
+
+            @model_observer(models.Test, serializer_class=TestSerializer)
+            async def model_change(self, message, action=None, **kwargs):
+                await self.reply(data=message, action=action)
+
+
 Subscribing to a filtered list of models
 ========================================
 

--- a/djangochannelsrestframework/observer/base_observer.py
+++ b/djangochannelsrestframework/observer/base_observer.py
@@ -117,6 +117,28 @@ class BaseObserver:
                     async def subscribe_to_comment_activity(self, **kwargs):
                         await self.comment_activity.subscribe()
 
+
+            .. note::
+
+                New feature! This can be rewriting as
+                    .. code-block:: python
+
+                        ...
+
+                        class MyConsumer(GenericAsyncAPIConsumer):
+                            queryset = User.objects.all()
+                            serializer_class = UserSerializer
+
+                            @model_observer(Comments, serializer_class=CommentSerializer)
+                            async def comment_activity(self, message, action, **kwargs):
+                                await self.reply(data=message, action=action)
+
+                            @action()
+                            async def subscribe_to_comment_activity(self, **kwargs):
+                                await self.comment_activity.subscribe()
+
+
+
             Now we will have a websocket client in javascript listening to the messages, after subscribing to the comment activity.
             This codeblock can be used it in the browser console.
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -470,7 +470,39 @@ async def test_model_observer_with_class_serializer(settings):
             "username": user.username,
         },
     } == response
+
+    user.username = "test updated"
+    await database_sync_to_async(user.save)()
+
+    response = await communicator.receive_json_from()
+
+    assert {
+        "action": "update",
+        "response_status": 200,
+        "request_id": None,
+        "errors": [],
+        "data": {
+            "id": user.pk,
+            "username": user.username,
+        },
+    } == response
     
+    pk = user.pk
+    await database_sync_to_async(user.delete)()
+
+    response = await communicator.receive_json_from()
+
+    assert {
+        "action": "delete",
+        "response_status": 200,
+        "request_id": None,
+        "errors": [],
+        "data": {
+            "id": pk,
+            "username": user.username,
+        },
+    } == response
+
     await communicator.disconnect()
 
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -13,6 +13,7 @@ from django.utils.text import slugify
 from djangochannelsrestframework.consumers import AsyncAPIConsumer
 from djangochannelsrestframework.observer import observer, model_observer
 
+from rest_framework import serializers
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
@@ -419,6 +420,58 @@ async def test_model_observer_custom_groups_wrapper(settings):
     # no event since this is only subscribed to 'test'
     with pytest.raises(asyncio.TimeoutError):
         await communicator.receive_json_from()
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_model_observer_with_class_serializer(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500,},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
+    class UserSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = get_user_model()
+            fields = ['id', 'username']
+
+
+    class TestConsumerObserverUsers(AsyncAPIConsumer):
+        async def accept(self, **kwargs):
+            await self.users_changes.subscribe()
+            await super().accept()
+
+        @model_observer(get_user_model(), serializer_class=UserSerializer)
+        async def users_changes(self, message, action, **kwargs):
+            await self.reply(data=message, action=action)
+
+    communicator = WebsocketCommunicator(TestConsumerObserverUsers(), "/testws/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected
+
+    user = await database_sync_to_async(get_user_model().objects.create)(
+        username="test", email="test@example.com"
+    )
+
+    response = await communicator.receive_json_from()
+    
+    assert {
+        "action": "create",
+        "response_status": 200,
+        "request_id": None,
+        "errors": [],
+        "data": {
+            "id": user.pk,
+            "username": user.username,
+        },
+    } == response
+    
+    await communicator.disconnect()
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
I added a logic to pass a kwargs to the ``@model_observer`` decorator, this way it handles automatically the serialization 