### PR TITLE
add request_id support to subscribe and un-subscribe from observers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ DCRF is based of a fork of `Channels Api <https://github.com/linuxlewis/channels
 
 Documentation
 -------------
-doc_
+ReadTheDocs_
 
 
 Install
@@ -174,6 +174,22 @@ Using your normal views over a websocket connection
    })
 
 
+
+In this situation if your view needs to read the `GET` query string values you can provides these using the `query` option.
+And if the view method reads parameters from the URL you can provides these with the `parameters`.
+
+Sending the following over your WS connection will result in a GET request being evaluated on your View.
+
+.. code-block:: json
+
+    {
+      action: "retrieve",
+      query: {"user_id": 42}
+      parameters: {"project_id": 92}
+    }
+
+
+
 Subscribing to a signal.
 ------------------------
 
@@ -210,8 +226,9 @@ for manually trigger the signal.
             return {}, status.HTTP_204_NO_CONTENT
 
         @observer(signal=joined_chat_signal)
-        async def joined_chat_handler(self, data, observer=None, action=None, **kwargs):
-            await self.reply(action='joined_chat', data=data, status=status.HTTP_200_OK)
+        async def joined_chat_handler(self, data, observer=None, action=None, subscribing_request_ids=[], **kwargs):
+            for request_id in subscribing_request_ids:
+                await self.reply(action='joined_chat', data=data, status=status.HTTP_200_OK, request_id=request_id)
 
         @joined_chat_handler.serializer
         def join_chat_handler(self, sender, data, **kwargs): # the data comes from the signal.send and will be available in the observer
@@ -227,8 +244,8 @@ for manually trigger the signal.
                 yield f'chat__{chat}'
 
         @action()
-        async def subscribe_joined(self, chat_id, **kwargs):
-            await self.joined_chat_handler.subscribe(chat_id)
+        async def subscribe_joined(self, chat_id, request_id, **kwargs):
+            await self.joined_chat_handler.subscribe(chat_id, request_id=request_id)
 
 
 Subscribing to all instances of a model
@@ -289,11 +306,26 @@ Another way is override ``AsyncAPIConsumer.accept(self, **kwargs)``
 
         @model_observer(models.Test)
         async def model_change(self, message, action=None, **kwargs):
+            """
+            This method is evaluated once for every user that subscribed,
+            here you have access to info about the user by reading `self.scope`
+
+            However it is best to avoid doing DB quires here since if you have lots of
+            subscribers to a given instance you will end up with a LOT of database traffic.
+            """
             await self.send_json(message)
         
         ''' If you want the data serialized instead of pk '''
         @model_change.serializer
         def model_serialize(self, instance, action, **kwargs):
+            """
+            This block is evaluated before the data is sent over the channel layer
+            this means you are unable to access information
+            such as the user that it will be sent to.
+
+            If you need the user info when serializing then you can do the serialization
+            in the above method.
+            """
             return TestSerializer(instance).data
 
 .. note::
@@ -310,6 +342,8 @@ Another way is override ``AsyncAPIConsumer.accept(self, **kwargs)``
 
             @model_observer(models.Test, serializer_class=TestSerializer)
             async def model_change(self, message, action=None, **kwargs):
+                # in this case since we subscribe int he `accept` method
+                # we do not expect to have any `subscribing_request_ids` to loop over.
                 await self.reply(data=message, action=action)
 
 
@@ -324,13 +358,26 @@ To do this we need to split the model updates into `groups` and then in the cons
 .. code-block:: python
 
   class MyConsumer(AsyncAPIConsumer):
+    # This class MUST subclass `AsyncAPIConsumer` to use `@model_observer`
 
     @model_observer(models.Classroom)
-    async def classroom_change_handler(self, message, observer=None, action=None, **kwargs):
+    async def classroom_change_handler(
+        self,
+        message,
+        observer=None,
+        action=None,
+        subscribing_request_ids=[],
+        **kwargs
+    ):
         # due to not being able to make DB QUERIES when selecting a group
         # maybe do an extra check here to be sure the user has permission
         # send activity to your frontend
-        await self.send_json(dict(body=message, action=action))
+        for request_id in subscribing_request_ids:
+            # we can send a seperate message for each subscribing request
+            # this lets ws clients rout these messages.
+            await self.send_json(dict(body=message, action=action, request_id=request_id))
+        # note if we do not pass `request_id` to the `subscribe` method
+        # then `subscribing_request_ids` will be and empty list.
 
     @classroom_change_handler.groups_for_signal
     def classroom_change_handler(self, instance: models.Classroom, **kwargs):
@@ -347,17 +394,17 @@ To do this we need to split the model updates into `groups` and then in the cons
             yield f'-pk__{classroom.pk}'
 
     @action()
-    async def subscribe_to_classrooms_in_school(self, school_pk, **kwargs):
+    async def subscribe_to_classrooms_in_school(self, school_pk, request_id, **kwargs):
         # check user has permission to do this
-        await self.classroom_change_handler.subscribe(school=school)
+        await self.classroom_change_handler.subscribe(school=school, request_id=request_id)
 
     @action()
-    async def subscribe_to_classroom(self, classroom_pk, **kwargs):
+    async def subscribe_to_classroom(self, classroom_pk, request_id, **kwargs):
         # check user has permission to do this
-        await self.classroom_change_handler.subscribe(classroom=classroom)
+        await self.classroom_change_handler.subscribe(classroom=classroom, request_id=request_id)
 
 
-.. _doc: https://djangochannelsrestframework.readthedocs.io/en/latest/
+.. _ReadTheDocs: https://djangochannelsrestframework.readthedocs.io/en/latest/
 .. _post: https://lostmoa.com/blog/DjangoChannelsRestFramework/
 .. _GenericAPIView: https://www.django-rest-framework.org/api-guide/generic-views/
 .. _channels-v3: https://channels.readthedocs.io/en/latest/

--- a/djangochannelsrestframework/consumers.py
+++ b/djangochannelsrestframework/consumers.py
@@ -1,8 +1,9 @@
 import asyncio
 import json
 import typing
+from collections import defaultdict
 from functools import partial
-from typing import Dict, List, Type
+from typing import Dict, List, Type, Any, Set
 
 from channels.consumer import AsyncConsumer
 from channels.db import database_sync_to_async
@@ -56,10 +57,16 @@ class AsyncAPIConsumer(AsyncJsonWebsocketConsumer, metaclass=APIConsumerMetaclas
     )  # type: List[Type[BasePermission]]
 
     groups = {}
+    # mapping observer id -> group name ->
+    _observer_group_to_request_id: Dict[str, Dict[str, Set[Any]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.groups = set(self.groups or [])
+
+        self._observer_group_to_request_id = defaultdict(lambda: defaultdict(set))
 
     async def add_group(self, name: str):
         if not isinstance(self.groups, set):
@@ -178,7 +185,6 @@ class AsyncAPIConsumer(AsyncJsonWebsocketConsumer, metaclass=APIConsumerMetaclas
 
 
 class DjangoViewAsConsumer(AsyncAPIConsumer):
-
     view = None
 
     @property

--- a/djangochannelsrestframework/observer/model_observer.py
+++ b/djangochannelsrestframework/observer/model_observer.py
@@ -49,7 +49,9 @@ class ModelObserverInstanceState:
 class ModelObserver(BaseObserver):
     def __init__(self, func, model_cls: Type[Model], partition: str = "*", **kwargs):
         super().__init__(func, partition=partition)
-        self._serializer_class = kwargs['kwargs'].get('serializer_class') if 'kwargs' in kwargs else None  # type: Optional[Serializer]
+        self._serializer_class = (
+            kwargs["kwargs"].get("serializer_class") if "kwargs" in kwargs else None
+        )  # type: Optional[Serializer]
         self._serializer = None
         self._model_cls = None
         self.model_cls = model_cls  # type: Type[Model]

--- a/djangochannelsrestframework/observer/model_observer.py
+++ b/djangochannelsrestframework/observer/model_observer.py
@@ -1,10 +1,9 @@
-import threading
 import warnings
 from collections import defaultdict
 from copy import deepcopy
 from enum import Enum
 from functools import partial
-from typing import Type, Dict, Any, Set, overload, Optional
+from typing import Type, Dict, Any, Set, Optional
 from uuid import uuid4
 
 from asgiref.sync import async_to_sync
@@ -14,21 +13,7 @@ from django.db.models import Model
 from django.db.models.signals import post_delete, post_save, post_init
 from rest_framework.serializers import Serializer
 
-from djangochannelsrestframework.consumers import AsyncAPIConsumer
 from djangochannelsrestframework.observer.base_observer import BaseObserver
-
-"""
-1) not in transaction
-2) in a simple transation with one operations
-3) in a simple transation with mutliple operations
-4) was in a transation but rolled back then outside of a transation saved
-5) was in a transatino but rolled back then inside a new one saved
-6) in a transations savepoint that is never saved
-7) in a transation and then in a save point
-
-
-On each model instance we add a `__observers = {self(id): {tracking info}}`
-"""
 
 
 class Action(Enum):

--- a/docs/examples/filtered_model_observer.rst
+++ b/docs/examples/filtered_model_observer.rst
@@ -62,7 +62,13 @@ These are the important methods of the class.
         serializer_class = UserSerializer
         
         @model_observer(Comments)
-        async def comment_activity(self, message: CommentSerializer, observer=None, **kwargs):
+        async def comment_activity(
+            self,
+            message: CommentSerializer,
+            observer=None,
+            subscribing_request_ids=[],
+            **kwargs
+        ):
             await self.send_json(message.data)
 
         @comment_activity.serializer
@@ -81,10 +87,10 @@ These are the important methods of the class.
             yield f'-user__{self.scope["user"].pk}'
 
         @action()
-        async def subscribe_to_comment_activity(self, **kwargs):
+        async def subscribe_to_comment_activity(self, request_id, **kwargs):
             # We will check if the user is authenticated for subscribing.
             if "user" in self.scope and self.scope["user"].is_authenticated:
-                await self.comment_activity.subscribe()
+                await self.comment_activity.subscribe(request_id=request_id)
 
 .. note::
     Without logging in we will have to access the ``user`` using the pk or any other unique field.

--- a/docs/examples/model_observer.rst
+++ b/docs/examples/model_observer.rst
@@ -59,7 +59,13 @@ These are the important methods of the class.
         serializer_class = UserSerializer
         
         @model_observer(Comments)
-        async def comment_activity(self, message: CommentSerializer, observer=None, **kwargs):
+        async def comment_activity(
+            self,
+            message: CommentSerializer,
+            observer=None,
+            subscribing_request_ids=[]
+            **kwargs
+        ):
             await self.send_json(message.data)
 
         @comment_activity.serializer
@@ -68,8 +74,8 @@ These are the important methods of the class.
             return CommentSerializer(instance)
 
         @action()
-        async def subscribe_to_comment_activity(self, **kwargs):
-            await self.comment_activity.subscribe()
+        async def subscribe_to_comment_activity(self, request_id, **kwargs):
+            await self.comment_activity.subscribe(request_id=request_id)
 
 Manual testing the output.
 --------------------------

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -10,7 +10,7 @@ from django.contrib.auth import user_logged_in, get_user_model
 from django.db import transaction
 from django.utils.text import slugify
 
-from decorators import action
+from djangochannelsrestframework.decorators import action
 from djangochannelsrestframework.consumers import AsyncAPIConsumer
 from djangochannelsrestframework.observer import observer, model_observer
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -10,10 +10,12 @@ from django.contrib.auth import user_logged_in, get_user_model
 from django.db import transaction
 from django.utils.text import slugify
 
+from decorators import action
 from djangochannelsrestframework.consumers import AsyncAPIConsumer
 from djangochannelsrestframework.observer import observer, model_observer
 
 from rest_framework import serializers
+
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
@@ -30,7 +32,7 @@ async def test_observer_wrapper(settings):
     layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
 
     class TestConsumer(AsyncAPIConsumer):
-        async def accept(self):
+        async def accept(self, **kwargs):
             await self.handle_user_logged_in.subscribe()
             await super().accept()
 
@@ -421,13 +423,16 @@ async def test_model_observer_custom_groups_wrapper(settings):
     with pytest.raises(asyncio.TimeoutError):
         await communicator.receive_json_from()
 
+
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_model_observer_with_class_serializer(settings):
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
-            "TEST_CONFIG": {"expiry": 100500,},
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
         },
     }
 
@@ -436,8 +441,7 @@ async def test_model_observer_with_class_serializer(settings):
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
-            fields = ['id', 'username']
-
+            fields = ["id", "username"]
 
     class TestConsumerObserverUsers(AsyncAPIConsumer):
         async def accept(self, **kwargs):
@@ -459,7 +463,7 @@ async def test_model_observer_with_class_serializer(settings):
     )
 
     response = await communicator.receive_json_from()
-    
+
     assert {
         "action": "create",
         "response_status": 200,
@@ -486,7 +490,7 @@ async def test_model_observer_with_class_serializer(settings):
             "username": user.username,
         },
     } == response
-    
+
     pk = user.pk
     await database_sync_to_async(user.delete)()
 
@@ -566,3 +570,81 @@ async def test_model_observer_custom_groups_wrapper_with_split_function_api(sett
     # no event since this is only subscribed to 'test'
     with pytest.raises(asyncio.TimeoutError):
         await communicator.receive_json_from()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_model_observer_with_request_id(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {
+                "expiry": 100500,
+            },
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
+    class TestConsumerObserverCustomGroups(AsyncAPIConsumer):
+        @action()
+        async def subscribe(self, username, request_id, **kwargs):
+            await self.user_change_custom_groups.subscribe(
+                username=username, request_id=request_id
+            )
+
+        @model_observer(get_user_model())
+        async def user_change_custom_groups(
+            self,
+            message,
+            action,
+            message_type,
+            observer=None,
+            subscribing_request_ids=None,
+            **kwargs
+        ):
+            await self.send_json(
+                dict(
+                    body=message,
+                    action=action,
+                    type=message_type,
+                    subscribing_request_ids=subscribing_request_ids,
+                )
+            )
+
+        @user_change_custom_groups.groups_for_signal
+        def user_change_custom_groups(self, instance=None, **kwargs):
+            yield "-instance-username-{}".format(instance.username)
+
+        @user_change_custom_groups.groups_for_consumer
+        def user_change_custom_groups(self, username=None, **kwargs):
+            yield "-instance-username-{}".format(slugify(username))
+
+    communicator = WebsocketCommunicator(TestConsumerObserverCustomGroups(), "/testws/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected
+
+    await communicator.send_json_to(
+        {
+            "action": "subscribe",
+            "username": "thenewname",
+            "request_id": 5,
+        }
+    )
+
+    user = await database_sync_to_async(get_user_model().objects.create)(
+        username="thenewname", email="test@example.com"
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert {
+        "action": "create",
+        "body": {"pk": user.pk},
+        "type": "user.change.custom.groups",
+        "subscribing_request_ids": [5],
+    } == response
+
+    await communicator.disconnect()


### PR DESCRIPTION
`.subscribe(..)` now takes an optional `request_id` value. if provided this is tracked and the body of the observer is provided with a list of request ids that subscribed to it.

In addition if request_id is provided to the `unsubscribe` method then it will correctly un-subscribe only that request. 

the body of the observer method is now called with the kw arg `subscribing_request_ids`. 


```python
        @action()
        async def subscribe(self, username, request_id, **kwargs):
            await self.user_change_custom_groups.subscribe(
                username=username, request_id=request_id
            )

        @model_observer(get_user_model())
        async def user_change_custom_groups(
            self,
            message,
            action,
            message_type,
            observer=None,
            subscribing_request_ids=[],
            **kwargs
        ): 
            # note if when subscribing you do not provide the request id this list here will be empty.
            for request_id in subscribing_request_ids:
                await self.send_json(
                   dict(
                       body=message,
                       action=action,
                       type=message_type,
                       request_id= request_id,
                    )
                )
```